### PR TITLE
FDK-320 cucumber test to check that required subject headers are displayed

### DIFF
--- a/bddtest/src/test/java/no/dcat/bddtest/cucumber/glue/DetailPageSubjectsSteps.java
+++ b/bddtest/src/test/java/no/dcat/bddtest/cucumber/glue/DetailPageSubjectsSteps.java
@@ -1,0 +1,61 @@
+package no.dcat.bddtest.cucumber.glue;
+
+import cucumber.api.DataTable;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by bjg on 15.02.2017.
+ */
+public class DetailPageSubjectsSteps extends CommonPage {
+    @Before
+    public void setup() {
+        setupDriver();
+    }
+
+    @After
+    public void shutdown() {
+        stopDriver();
+    }
+
+
+    @When("^I open the dataset with id \"([^\"]*)\"$")
+    public void i_open_the_dataset_with_id(String datasetId) throws Throwable {
+        // Write code here that turns the phrase above into concrete actions
+        openPage("/datasets?id=" + datasetId);
+    }
+
+
+    @Then("^the detailpage shall appear$")
+    public void the_detailpage_shall_appear() throws Throwable {
+        assertTrue("The page has correct title: Detail view", driver.getTitle().equals("Detail view"));
+    }
+
+
+    @Then("^display the following headers:$")
+    public void display_the_following_headers(DataTable headerTable) throws Throwable {
+        // Write code here that turns the phrase above into concrete actions
+        // For automatic transformation, change DataTable to one of
+        // List<YourType>, List<List<E>>, List<Map<K,V>> or Map<K,V>.
+        // E,K,V must be a scalar (String, Integer, Date, enum etc)
+        try {
+            List<List<String>> headers = headerTable.raw();
+
+            for (List<String> headerValues : headers) {
+                String headerName = headerValues.get(0);
+                WebElement headerElement = driver.findElement(By.xpath("//h3[.='" + headerName +"']"));
+                assertTrue("Header element should be found", headerElement != null);
+            }
+        } finally {
+            driver.close();
+        }
+    }
+}

--- a/bddtest/src/test/resources/feature/1_FDK-320-detailpageSubjects.feature
+++ b/bddtest/src/test/resources/feature/1_FDK-320-detailpageSubjects.feature
@@ -1,0 +1,37 @@
+Feature: Design - detaljsiden
+	#Vise samme felter som før. Kun bokmål.
+	#
+	#+ last ned knapp/lenke
+	#+ feit katalog
+	#+ felt identifier
+	#
+	#Godkjenningskriterie: (gitt jeg er på detaljsiden)
+	## jeg får opp overskriftene: Kontaktinformasjon, Distrubusjon, Opplysninger, Restriksjoner, Formål, Relaterte, Kvalitet og Øvrig info
+	## jeg kan se tittel, beskrivelse, utgiver og landingsside
+	## jeg kan se katalogen datasettet opprinnelig er publisert i
+	## jeg kan se alle feltene i datesettet som har verdier
+	## jeg kan velge å laste ned datasettet i ulike formater 
+	## brukergrensesnittet skal være i henhold til wire-frames/CSS og godkjent av designer
+
+	Background:
+		Given Elasticsearch kjører
+		And bruker datasett dataset-detailpage.ttl
+		And man har åpnet Fellesdatakatalog i en nettleser
+		
+
+	#gitt jeg er på detaljsiden da får jeg opp overskriftene: Kontaktinformasjon, Distribusjon, Opplysninger, Restriksjoner, Formål, Relaterte, Kvalitet og Øvrig info
+	# @TEST_FDK_320 @TESTSETT_FDK_313 @portal
+	Scenario: C-Test FDK: Design detaljsiden - tittel, beskrivelse, utgiver og landingsside
+		When I open the dataset with id "http://data.brreg.no/datakatalog/dataset/1"
+		Then the detailpage shall appear
+		And display the following headers:
+		
+		| Kontaktinformasjon |
+		| Konformitet |
+		| Kvalitet |
+		| Øvrig info |
+		| Opplysninger |
+		| Restriksjoner |
+		| Formål |
+		| Relaterte |
+		


### PR DESCRIPTION
Cucumber-test som sjekker om de forventede overskriftene vises på detaljsiden.

Mens jeg jobbet med denne ,ble jeg litt usikker på hvor nødvendig den er. Den sjekker kun at spesifiserte overskrifter finnes. Dette kunne kanskje vært en ren ui-test av portalen. Testen er heller ikke særlig robust, den bruker xpath for å finne H3-elementer. Alle overskriftene er formatert som H3 i dag, men ikke sikkert de vil være det i fremtiden. Elementene får ingen id, så jeg kan ikke søke på det.

Dere får vurdere om testen er nødvendig å ta med. Den ble litt annerledes enn jeg trodde da Guro og jeg diskuterte dette i går ettermiddag.