### PR TITLE
Hotfix/publisher harvest

### DIFF
--- a/harvester/src/main/java/no/dcat/harvester/crawler/converters/BrregAgentConverter.java
+++ b/harvester/src/main/java/no/dcat/harvester/crawler/converters/BrregAgentConverter.java
@@ -15,6 +15,7 @@ import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.sparql.vocabulary.FOAF;
+import org.apache.jena.util.ResourceUtils;
 import org.apache.jena.vocabulary.DCTerms;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,7 @@ public class BrregAgentConverter {
                 .setBaseNamespace("http://data.brreg.no/meta/", Builder.AppliesTo.bothElementsAndAttributes)
                 .convertComplexElementsWithOnlyAttributesAndSimpleTypeChildrenToPredicate(true)
                 .convertComplexElementsWithOnlyAttributesToPredicate(true)
+                //.uuidBasedIdInsteadOfBlankNodes("dcat://meta/") // generates uuid for blank nodes
                 .renameElement("http://data.brreg.no/meta/navn", FOAF.name.getURI())
                 .renameElement("http://data.brreg.no/meta/enhet", FOAF.Agent.getURI()).build();
         logger.debug("end ");
@@ -115,6 +117,7 @@ public class BrregAgentConverter {
 
                 logger.trace("[model_after_conversion] {}", incomingModel);
                 removeDuplicateProperties(model, incomingModel, FOAF.name); //TODO: remove all duplicate properties?
+                processBlankNodes(incomingModel, uri);
 
                 ResIterator subjects = incomingModel.listSubjectsWithProperty(EnhetsregisteretRDF.organisasjonsform);
 
@@ -129,7 +132,7 @@ public class BrregAgentConverter {
                         collectFromUri(String.format(publisherIdURI, overordnetEnhet.getObject().toString()), model);
                     }
                 }
-
+                logger.trace(incomingModel.toString());
                 model.add(incomingModel);
             } else {
                 logger.warn("Unable to look up publisher {} - cache is not initiatilized.", uri);
@@ -139,6 +142,41 @@ public class BrregAgentConverter {
         } catch (Exception e) {
             logger.warn("Failed to look up publisher: {} reason {}", uri, e.getMessage(),e);
         }
+    }
+
+    /**
+     * find forretningsadresse, naeringskode1, postadresse og institusjonellSektorkode
+     * resources and change their blank nodes to a fixed uri
+     */
+    private void processBlankNodes(Model model, String resourceURI) {
+        final String namespace = "http://data.brreg.no/meta/";
+        final String[] properties = {
+                "forretningsadresse",
+                "postadresse",
+                "naeringskode1",
+                "institusjonellSektorkode"
+        };
+
+        if (resourceURI.endsWith(".xml")) {
+            resourceURI = resourceURI.substring(0,resourceURI.indexOf(".xml"));
+        }
+
+        for (String localName : properties ) {
+
+            Property property = model.getProperty(namespace, localName);
+            NodeIterator nodes = model.listObjectsOfProperty(property);
+            if (nodes.hasNext()) {
+                RDFNode blankNode = nodes.next();
+                if (blankNode.isResource() && blankNode.isAnon()) {
+                    Resource resource = blankNode.asResource();
+                    String newUri = resourceURI + "/" + localName;
+                    logger.debug("Renames {} blank node {} to {}",resourceURI, resource.getId(), newUri);
+                    ResourceUtils.renameResource(resource, newUri );
+                }
+            }
+
+        }
+
     }
 
     /**

--- a/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
+++ b/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
@@ -97,17 +97,17 @@ public class PortalRestController {
                 "PREFIX foaf: <http://xmlns.com/foaf/0.1/>" +
                 "PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>" +
                 "PREFIX dcatno: <http://difi.no/dcatno#>" +
-                "PREFIX enhetsreg: <http://data.brreg.no/meta/>" +
-                "DESCRIBE ?dataset ?publisher ?contact ?distribution ?fadr ?padr ?sektor ?nace" +
+                "PREFIX er: <http://data.brreg.no/meta/>" +
+                "DESCRIBE ?dataset ?publisher ?contact ?distribution ?nace ?fadr ?padr ?sektor " +
                 "where {?dataset a dcat:Dataset. " +
                 " ?dataset dct:publisher ?publisher." +
-                        "OPTIONAL {?publisher enhetsreg:forretningsadresse ?fadr}" +
-                        "OPTIONAL {?publisher enhetsreg:postadresse ?padr}" +
-                        "OPTIONAL {?publisher enhetsreg:institusjonellSektorkode ?sektor}" +
-                        "OPTIONAL {?publisher enhetsreg:naeringskode1 ?nace}" +
+                        " OPTIONAL {?publisher er:naeringskode1 ?nace}" +
+                        " OPTIONAL {?publisher er:forretningsadresse ?fadr}" +
+                        " OPTIONAL {?publisher er:postadresse ?padr}" +
+                        " OPTIONAL {?publisher er:institusjonellSektorkode ?sektor}" +
                 " OPTIONAL {?dataset dcat:contactPoint ?contact} " +
                 " OPTIONAL {?dataset dcat:distribution ?distribution }" +
-                "FILTER (?dataset = <" + decodedUri + "> )" +
+                " FILTER (?dataset = <" + decodedUri + "> ) " +
                 "}";
 
         Query query = QueryFactory.create(queryString);

--- a/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
+++ b/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
@@ -98,9 +98,13 @@ public class PortalRestController {
                 "PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>" +
                 "PREFIX dcatno: <http://difi.no/dcatno#>" +
                 "PREFIX enhetsreg: <http://data.brreg.no/meta/>" +
-                "DESCRIBE ?dataset ?publisher ?contact ?distribution" +
+                "DESCRIBE ?dataset ?publisher ?contact ?distribution ?fadr ?padr ?sektor ?nace" +
                 "where {?dataset a dcat:Dataset. " +
                 " ?dataset dct:publisher ?publisher." +
+                        "OPTIONAL {?publisher enhetsreg:forretningsadresse ?fadr}" +
+                        "OPTIONAL {?publisher enhetsreg:postadresse ?padr}" +
+                        "OPTIONAL {?publisher enhetsreg:institusjonellSektorkode ?sektor}" +
+                        "OPTIONAL {?publisher enhetsreg:naeringskode1 ?nace}" +
                 " OPTIONAL {?dataset dcat:contactPoint ?contact} " +
                 " OPTIONAL {?dataset dcat:distribution ?distribution }" +
                 "FILTER (?dataset = <" + decodedUri + "> )" +

--- a/portal/webapp/src/main/resources/templates/theme.html
+++ b/portal/webapp/src/main/resources/templates/theme.html
@@ -27,10 +27,10 @@
 
     <div class="row">
         <section class="frontpage-themes">
-            <a th:each="t : ${themes}" th:href="${'/datasets?theme=' + {t.code}}"
-               th:attr="id=${(lang == 'en' ? t.title.get('en') : t.title.get('nb'))}">
+            <a th:each="t : ${themes}" th:href="${'/datasets?theme=' + t.code + '&amp;lang=' + lang}"
+               th:attr="id=${t.title.get(lang)}">
                     <span class="fdk-label fdk-label-default">
-                         <span th:text="${(lang == 'en' ? t.title.get('en') : t.title.get('nb'))}"/>
+                         <span th:text="${t.title.get(lang)}"/>
                         (<span name="hits" th:text="${t.numberOfHits}"/>)
                     </span>
             </a>


### PR DESCRIPTION
Fikset bug i utlegget av feltene fra enhetsregisteret. Disse ble blanknoder og Jena slo dem derfor sammen. Har fikset det med å lage unike uri-er for forretningsadresse, postadresse, sektorielinstitusjonskode og næringskode1. Har også lagt til lang på hrefene på temasiden.