### PR TITLE
Feature/fdk 421 vegvesen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,25 @@
 # Felles datakatalog
 
-Dette er den første felleskomponenten som utvikles i regi av Skate (https://www.difi.no/fagomrader-og-tjenester/digitalisering-og-samordning/skate). Felles datakatalog skal tilby en oversikt over hvilke datasett som offentlige virksomheter har. Det skal tilbys en søkeløsning (portal) som gjør det mulig å søke og finne relevante datasettbeskrivelser. Prosjektet går over 2 år med oppstart høsten 2016. Det er basert på en norsk profil DCAT-AP-NO 1.1 av en Europeisk og W3C standard for utveksling av datasettbeskrivelser. Det er basert på kode som ble utviklet i DIFIs pilotprosjekt: Nasjonal infrastruktur for felles datakatalog (våren 2016). 
+Dette er den første felleskomponenten som utvikles i regi av 
+Skate (https://www.difi.no/fagomrader-og-tjenester/digitalisering-og-samordning/skate). 
+Felles datakatalog skal tilby en oversikt over hvilke datasett som offentlige
+virksomheter har. Det skal tilbys en søkeløsning (portal) som gjør det mulig å 
+søke og finne relevante datasettbeskrivelser. Prosjektet går over 2 år med 
+oppstart høsten 2016. Forventet ferdig ved utgangen av 2017. 
+
+Systemet er basert på en norsk profil DCAT-AP-NO 1.1 av en Europeisk og W3C standard
+for utveksling av datasettbeskrivelser, se https://doc.difi.no/dcat-ap-no/. 
+Systemet bygger videre på kode som ble utviklet i DIFIs pilotprosjekt: 
+Nasjonal infrastruktur for felles datakatalog (våren 2016). 
 
 ## Struktur
 
 Applikasjoner
 
-* portal: webapp + query
-* harvester: admin + service
-* api (currently not up)
-* test-admin
+* catalog: søkeløsning 
+* harvester: høster lokale løsninger og legger inn i søkeløsningen
+* registration: lar virksomheter registrere egne datasettbeskrivelser
+* support: ulike hjelpeverktøy
 
 Komponenter
 
@@ -33,7 +43,6 @@ docker-compose down
 
 ## Kjøre applikasjonene 
 
-
 Portal-webapp:
 http://localhost:8080
 
@@ -42,9 +51,7 @@ http://localhost:8081/
 
 Harvester-admin:
 http://localhost:8082/
-
-test_user password
-test_admin password
+(ta kontakt for passord)
 
 Portal-query:
 http://localhost:8083/search
@@ -54,6 +61,7 @@ http://localhost:8084/versions/latest
 
 Test-admin:
 http://localhost:8085/
+(ta kontakt for passord)
 
 Fuseki:
 http://localhost:3030/fuseki/

--- a/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalController.java
+++ b/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalController.java
@@ -97,7 +97,7 @@ public class PortalController {
         }
     }
 
-    private ModelAndView getDetailsView(@RequestParam(value = "id", defaultValue = "") String id) {
+    private ModelAndView getDetailsView(String id) {
         ModelAndView model = new ModelAndView("detail");
 
         try {
@@ -133,6 +133,7 @@ public class PortalController {
      * @return One Dataset attatched to a ModelAndView.
      */
     @RequestMapping(value = {"/detail"}, produces = "text/html")
+    @Deprecated
     public ModelAndView detail(@RequestParam(value = "id", defaultValue = "") String id) {
 
         return getDetailsView(id);

--- a/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
+++ b/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
@@ -290,6 +290,9 @@ public class PortalRestController {
             ModelFormatter modelFormatter = new ModelFormatter(submodel);
 
             return modelFormatter.format(format);
+        } catch (Exception e) {
+            logger.error("No resource found {}", e.getClass().getName(), e);
+            return null;
         }
     }
 
@@ -309,7 +312,7 @@ public class PortalRestController {
      * @param query sparql query
      * @return the execution handler of the query
      */
-    QueryExecution getQueryExecution(Query query) {
+    QueryExecution getQueryExecution(Query query) throws Exception {
         return new QueryEngineHTTP(getFusekiService() + "/dcat", query);
     }
 

--- a/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
+++ b/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
@@ -7,6 +7,7 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.sparql.engine.http.QueryEngineHTTP;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -312,7 +313,7 @@ public class PortalRestController {
      * @param query sparql query
      * @return the execution handler of the query
      */
-    QueryExecution getQueryExecution(Query query) throws Exception {
+    QueryExecution getQueryExecution(Query query) throws QueryExceptionHTTP {
         return new QueryEngineHTTP(getFusekiService() + "/dcat", query);
     }
 

--- a/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
+++ b/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
@@ -76,8 +76,7 @@ public class PortalRestController {
     @RequestMapping(value = "/catalogs",
         method = GET,
         produces = "text/html")
-    public String getCatalogs(@RequestParam(value= "x", defaultValue="x") String x,
-                              @RequestHeader(value = "Accept", defaultValue = "*/*") String acceptHeader) {
+    public String getCatalogs(@RequestHeader(value = "Accept", defaultValue = "*/*") String acceptHeader) {
         final String queryFile = "sparql/allcatalogs.sparql";
 
         try {
@@ -91,6 +90,14 @@ public class PortalRestController {
 
                 StringBuilder builder = new StringBuilder();
 
+                builder.append("<html>");
+                builder.append("<head>");
+                builder.append("<link rel='stylesheet' href='webjars/bootstrap/3.3.7/css/bootstrap.min.css' media='all'/>");
+                builder.append("<link rel='stylesheet' href='css/main.css' media='all'/>");
+                builder.append("</head>");
+                builder.append("<body>");
+                builder.append("<h1>Velg katalog for nedlasting</h1>");
+
                 while (resultset.hasNext()) {
                     QuerySolution qs = resultset.next();
                     String catalogName = qs.get("cname").asLiteral().getString();
@@ -98,8 +105,12 @@ public class PortalRestController {
                     String publisherName = qs.get("pname").asLiteral().getString();
                     String publisherUri = qs.get("publisher").asResource().getURI();
 
-                    builder.append("<a href='"+ "http://localhost:8080/catalogs?id=" + catalogUri + "&format=ttl'>" + catalogName + "</a>\n" );
+                    builder.append("<a class='fdk-label fdk-label-default' href='"+ "/catalogs?id=" + catalogUri + "&format=ttl'>" + catalogName + "</a>\n" );
+
                 }
+
+                builder.append("</body>");
+                builder.append("</html>");
 
                 return builder.toString();
             }

--- a/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
+++ b/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
@@ -130,6 +130,10 @@ public class PortalRestController {
             } else {
                 return new ResponseEntity<String>("No catalogs found.", HttpStatus.NOT_FOUND);
             }
+        } catch (Exception e) {
+            logger.error("No catalogs found", e);
+            return new ResponseEntity<String>("No catalogs found: " + e.getClass().getName(),
+                    HttpStatus.NOT_FOUND);
         }
 
     }
@@ -189,6 +193,7 @@ public class PortalRestController {
             if (responseBody == null) {
                 return new ResponseEntity<>("Unable to find " + id, HttpStatus.NOT_FOUND);
             }
+
 
             HttpHeaders headers = new HttpHeaders();
             headers.add("Content-Type", returnFormat + "; charset=UTF-8");

--- a/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
+++ b/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
@@ -313,7 +313,7 @@ public class PortalRestController {
      * @param query sparql query
      * @return the execution handler of the query
      */
-    QueryExecution getQueryExecution(Query query) throws QueryExceptionHTTP {
+    QueryExecution getQueryExecution(Query query) {
         return new QueryEngineHTTP(getFusekiService() + "/dcat", query);
     }
 

--- a/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
+++ b/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalRestController.java
@@ -270,10 +270,22 @@ public class PortalRestController {
         return null;
     }
 
+    /**
+     * Creates a query based on a sparql text query
+     *
+     * @param query the sparql query
+     * @return the query object
+     */
     Query getQuery(String query) {
         return QueryFactory.create(query);
     }
 
+    /**
+     * Do query fuseki service
+     *
+     * @param query sparql query
+     * @return the execution handler of the query
+     */
     QueryExecution getQueryExecution(Query query) {
         return new QueryEngineHTTP(getFusekiService() + "/dcat", query);
     }

--- a/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalSecurityConfig.java
+++ b/portal/webapp/src/main/java/no/dcat/portal/webapp/PortalSecurityConfig.java
@@ -22,7 +22,7 @@ public class PortalSecurityConfig extends WebSecurityConfigurerAdapter {
 
         http
             .authorizeRequests()
-                .antMatchers("/", "/datasets").permitAll()
+                .antMatchers("/", "/datasets", "/publisher").permitAll()
                 //.anyRequest().authenticated()
                 .and()
             .formLogin()

--- a/portal/webapp/src/main/resources/sparql/allcatalogs.sparql
+++ b/portal/webapp/src/main/resources/sparql/allcatalogs.sparql
@@ -1,0 +1,20 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX http: <http://www.w3.org/2011/http#>
+PREFIX fo: <http://www.w3.org/1999/XSL/Format#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix er: <http://data.brreg.no/meta/>
+
+SELECT ?catalog ?cname ?publisher ?pname
+WHERE {
+
+  ?catalog a dcat:Catalog;
+   	dct:title ?cname;
+  	dct:publisher ?publisher.
+
+  ?publisher foaf:name ?pname.
+
+}

--- a/portal/webapp/src/main/resources/sparql/allcatalogs.sparql
+++ b/portal/webapp/src/main/resources/sparql/allcatalogs.sparql
@@ -16,5 +16,6 @@ WHERE {
   dct:publisher ?publisher.
 
   ?publisher foaf:name ?pname.
-
 }
+ORDER BY ?cname
+

--- a/portal/webapp/src/main/resources/sparql/allcatalogs.sparql
+++ b/portal/webapp/src/main/resources/sparql/allcatalogs.sparql
@@ -12,8 +12,8 @@ SELECT ?catalog ?cname ?publisher ?pname
 WHERE {
 
   ?catalog a dcat:Catalog;
-   	dct:title ?cname;
-  	dct:publisher ?publisher.
+  dct:title ?cname;
+  dct:publisher ?publisher.
 
   ?publisher foaf:name ?pname.
 

--- a/portal/webapp/src/main/resources/sparql/catalog.sparql
+++ b/portal/webapp/src/main/resources/sparql/catalog.sparql
@@ -1,0 +1,24 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX http: <http://www.w3.org/2011/http#>
+PREFIX fo: <http://www.w3.org/1999/XSL/Format#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix vcard: <http://www.w3.org/2006/vcard/ns#>
+prefix er: <http://data.brreg.no/meta/>
+
+DESCRIBE ?publisher ?dataset ?distribution ?catalog ?contact
+WHERE {
+
+  ?catalog a dcat:Catalog;
+   	dct:publisher ?publisher;
+  	dcat:dataset ?dataset.
+
+  ?dataset dcat:distribution ?distribution;
+    dcat:contactPoint ?contact.
+
+  FILTER (?catalog = <%s>)
+
+}

--- a/portal/webapp/src/main/resources/sparql/catalog.sparql
+++ b/portal/webapp/src/main/resources/sparql/catalog.sparql
@@ -11,13 +11,12 @@ prefix er: <http://data.brreg.no/meta/>
 
 DESCRIBE ?publisher ?dataset ?distribution ?catalog ?contact
 WHERE {
-
   ?catalog a dcat:Catalog;
-   	dct:publisher ?publisher;
-  	dcat:dataset ?dataset.
+  dct:publisher ?publisher;
+  dcat:dataset ?dataset.
 
-  ?dataset dcat:distribution ?distribution;
-    dcat:contactPoint ?contact.
+  OPTIONAL {?dataset dcat:distribution ?distribution}
+  OPTIONAL {?dataset dcat:contactPoint ?contact}
 
   FILTER (?catalog = <%s>)
 

--- a/portal/webapp/src/main/resources/sparql/dataset.sparql
+++ b/portal/webapp/src/main/resources/sparql/dataset.sparql
@@ -11,7 +11,7 @@ PREFIX er: <http://data.brreg.no/meta/>
 DESCRIBE ?dataset ?publisher ?contact ?distribution ?nace ?fadr ?padr ?sektor
 WHERE {
     ?dataset a dcat:Dataset;
-        dct:publisher ?publisher.
+    dct:publisher ?publisher.
 
     OPTIONAL {?publisher er:naeringskode1 ?nace}
     OPTIONAL {?publisher er:forretningsadresse ?fadr}

--- a/portal/webapp/src/main/resources/sparql/dataset.sparql
+++ b/portal/webapp/src/main/resources/sparql/dataset.sparql
@@ -1,0 +1,24 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX owl: <http://www.w3.org/TR/owl-time/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX dcatno: <http://difi.no/dcatno#>
+prefix vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX er: <http://data.brreg.no/meta/>
+
+DESCRIBE ?dataset ?publisher ?contact ?distribution ?nace ?fadr ?padr ?sektor
+WHERE {
+    ?dataset a dcat:Dataset;
+        dct:publisher ?publisher.
+
+    OPTIONAL {?publisher er:naeringskode1 ?nace}
+    OPTIONAL {?publisher er:forretningsadresse ?fadr}
+    OPTIONAL {?publisher er:postadresse ?padr}
+    OPTIONAL {?publisher er:institusjonellSektorkode ?sektor}
+    OPTIONAL {?dataset dcat:contactPoint ?contact}
+    OPTIONAL {?dataset dcat:distribution ?distribution }
+
+    FILTER (?dataset = <%s> )
+}

--- a/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
+++ b/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
@@ -34,7 +34,7 @@ public class DcatExportIntegrationTest {
         PortalRestController spy = spy(portal);
         doReturn("http://localhost:3030/fuseki").when(spy).getFusekiService();
 
-        String result = spy.getCatalogs("x","text/html");
+        String result = spy.getCatalogs("text/html");
 
         logger.info(result);
     }

--- a/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
+++ b/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
@@ -1,0 +1,52 @@
+package no.dcat.portal.webapp;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Created by dask on 20.03.2017.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+public class DcatExportIntegrationTest {
+
+    private static Logger logger = LoggerFactory.getLogger(DcatExportIntegrationTest.class);
+
+    private PortalRestController portal;
+
+    @Before
+    public void setup() {
+        portal = new PortalRestController();
+        // ReflectionTestUtils.setField(portal, "application.fusekiService", "http://localhost:3030/fuseki/dcat");
+    }
+
+    @Test
+    public void exportCatalogOK() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doReturn("http://localhost:3030/fuseki").when(spy).getFusekiService();
+
+        ResponseEntity<String> actual = spy.getCatalogDcat("http://data.brreg.no/datakatalog/katalog/974761076/5",
+                "ttl", "text/turtle");
+
+        logger.debug(actual.getBody());
+    }
+
+    @Test
+    public void exportDatasetOK() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doReturn("http://localhost:3030/fuseki").when(spy).getFusekiService();
+
+        ResponseEntity<String> actual = spy.getDatasourceDcat("http://data.brreg.no/datakatalog/dataset/974761076/63",
+                "ttl", "text/turtle");
+
+        logger.debug(actual.getBody());
+    }
+
+}

--- a/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
+++ b/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
@@ -34,7 +34,7 @@ public class DcatExportIntegrationTest {
         PortalRestController spy = spy(portal);
         doReturn("http://localhost:3030/fuseki").when(spy).getFusekiService();
 
-        String result = spy.getCatalogs();
+        String result = spy.getCatalogs("text/html");
 
         logger.info(result);
     }

--- a/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
+++ b/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
@@ -34,7 +34,7 @@ public class DcatExportIntegrationTest {
         PortalRestController spy = spy(portal);
         doReturn("http://localhost:3030/fuseki").when(spy).getFusekiService();
 
-        String result = spy.getCatalogs("text/html");
+        String result = spy.getCatalogs("x","text/html");
 
         logger.info(result);
     }

--- a/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
+++ b/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
@@ -43,7 +43,7 @@ public class DcatExportIntegrationTest {
         PortalRestController spy = spy(portal);
         doReturn("http://localhost:3030/fuseki").when(spy).getFusekiService();
 
-        ResponseEntity<String> actual = spy.getDatasourceDcat("http://data.brreg.no/datakatalog/dataset/974761076/63",
+        ResponseEntity<String> actual = spy.getDatasetDcat("http://data.brreg.no/datakatalog/dataset/974761076/63",
                 "ttl", "text/turtle");
 
         logger.debug(actual.getBody());

--- a/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
+++ b/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
@@ -34,9 +34,9 @@ public class DcatExportIntegrationTest {
         PortalRestController spy = spy(portal);
         doReturn("http://localhost:3030/fuseki").when(spy).getFusekiService();
 
-        String result = spy.getCatalogs("text/html");
+        ResponseEntity<String> result = spy.getCatalogs("text/html");
 
-        logger.info(result);
+        logger.info(result.getBody());
     }
 
     @Test

--- a/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
+++ b/portal/webapp/src/test/java/no/dcat/portal/webapp/DcatExportIntegrationTest.java
@@ -27,6 +27,18 @@ public class DcatExportIntegrationTest {
         // ReflectionTestUtils.setField(portal, "application.fusekiService", "http://localhost:3030/fuseki/dcat");
     }
 
+
+    @Test
+    public void getCatalogs() throws Throwable {
+
+        PortalRestController spy = spy(portal);
+        doReturn("http://localhost:3030/fuseki").when(spy).getFusekiService();
+
+        String result = spy.getCatalogs();
+
+        logger.info(result);
+    }
+
     @Test
     public void exportCatalogOK() throws Throwable {
         PortalRestController spy = spy(portal);

--- a/portal/webapp/src/test/java/no/dcat/portal/webapp/PortalRestControllerTest.java
+++ b/portal/webapp/src/test/java/no/dcat/portal/webapp/PortalRestControllerTest.java
@@ -41,6 +41,7 @@ public class PortalRestControllerTest {
         portal = new PortalRestController();
     }
 
+
     @Test
     public void getCatalogDcatOk() throws Throwable {
         PortalRestController spy = spy(portal);

--- a/portal/webapp/src/test/java/no/dcat/portal/webapp/PortalRestControllerTest.java
+++ b/portal/webapp/src/test/java/no/dcat/portal/webapp/PortalRestControllerTest.java
@@ -9,6 +9,7 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.algebra.optimize.TransformOrderByDistinctApplication;
 import org.apache.jena.sparql.engine.QueryEngineFactory;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -265,7 +266,7 @@ public class PortalRestControllerTest {
     @Test
     public void invokeFusekiQueryThrowsExceptionbecauseOfIOErrorInFuseki() throws Throwable {
         PortalRestController spy = spy(portal);
-        doThrow(new Exception("force exception")).when(spy).getQueryExecution(anyObject());
+        doThrow(new QueryExceptionHTTP(404, "force exception")).when(spy).getQueryExecution(anyObject());
 
         ResponseEntity<String> response = spy.invokeFusekiQuery("http://data.brreg.no/datakatalog/katalog/974761076/5",
                 null, "application/ld+json", "sparql/catalog.sparql");
@@ -276,7 +277,7 @@ public class PortalRestControllerTest {
     @Test
     public void getCatalogsThrowsExceptionBecauseOfIOErrorInFuseki() throws Throwable {
         PortalRestController spy = spy(portal);
-        doThrow(new Exception("force exception")).when(spy).getQueryExecution(anyObject());
+        doThrow(new QueryExceptionHTTP(406, "force exception")).when(spy).getQueryExecution(anyObject());
 
         ResponseEntity<String> response = spy.getCatalogs("*/*");
 

--- a/portal/webapp/src/test/java/no/dcat/portal/webapp/PortalRestControllerTest.java
+++ b/portal/webapp/src/test/java/no/dcat/portal/webapp/PortalRestControllerTest.java
@@ -1,0 +1,190 @@
+package no.dcat.portal.webapp;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RDFDataMgr;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Created by dask on 20.03.2017.
+ */
+public class PortalRestControllerTest {
+    private static Logger logger = LoggerFactory.getLogger(PortalRestControllerTest.class);
+
+    private PortalRestController portal;
+
+    @Before
+    public void setup() {
+        portal = new PortalRestController();
+    }
+
+    @Test
+    public void getCatalogDcatOk() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doReturn("DCAT format").when(spy).findResourceById(anyString(), anyString(), anyString());
+
+        ResponseEntity<String> response = spy.getCatalogDcat("http://data.brreg.no/datakatalog/katalog/974761076/5",
+                "ttl", "text/turtle");
+
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+    }
+
+    @Test
+    public void getDatasetDcatFormatsOK() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doReturn("DCAT format").when(spy).findResourceById(anyString(), anyString(), anyString());
+
+        final String[] acHeaders = {"application/ld+json", "json", "ld+json", "application/rdf+xml", "rdf", "text/turtle", "turtle"};
+        for (String ac : acHeaders) {
+            ResponseEntity<String> response = spy.getDatasetDcat("some id",
+                    null, ac);
+            assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        }
+
+        final String[] formats = {"ttl", "xml", "rdf", "json", "jsonld"};
+        for (String f : formats) {
+            ResponseEntity<String> response = spy.getDatasetDcat("some id",
+                    f, null);
+            assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        }
+    }
+
+    @Test
+    public void getCatalogDcatWrongAcceptHeader() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doReturn("DCAT format").when(spy).findResourceById(anyString(), anyString(), anyString());
+
+        ResponseEntity<String> response = spy.getCatalogDcat("http://data.brreg.no/datakatalog/katalog/974761076/5",
+                null, "XXXX");
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_ACCEPTABLE));
+    }
+
+    @Test
+    public void getCatalogDcatWrongFormat() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doReturn("DCAT format").when(spy).findResourceById(anyString(), anyString(), anyString());
+
+        ResponseEntity<String> response = spy.getCatalogDcat("http://data.brreg.no/datakatalog/katalog/974761076/5",
+                "WRONG", null);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_ACCEPTABLE));
+    }
+
+
+    @Test
+    public void getCatalogDcatIdNotFound() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doReturn(null).when(spy).findResourceById(anyString(), anyString(), anyString());
+
+        ResponseEntity<String> response = spy.getCatalogDcat("http://data.brreg.no/datakatalog/katalog/974761076/5",
+                null, "text/turtle");
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
+    }
+
+    @Test
+    public void getCatalogDcatIdThrowsNotFound() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doThrow(new NoSuchElementException("NSEE")).when(spy).findResourceById(anyString(), anyString(), anyString());
+
+        ResponseEntity<String> response = spy.getCatalogDcat("http://data.brreg.no/datakatalog/katalog/974761076/5",
+                null, "application/ld+json");
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
+    }
+
+    @Test
+    public void findResourceByIdOK() throws Throwable {
+        PortalRestController spy = spy(portal);
+        Resource mResource = new ClassPathResource("data.ttl");
+        org.apache.jena.query.Dataset dataset = RDFDataMgr.loadDataset(mResource.getURL().toString());
+        Model model = ModelFactory.createUnion(ModelFactory.createDefaultModel(), dataset.getDefaultModel());
+
+        //model.read(mResource.getInputStream(), "TURTLE");
+        doReturn(model).when(spy).getModel();
+
+        Resource queryResource = new ClassPathResource("sparql/catalog.sparql");
+        String queryString = read(queryResource.getInputStream());
+
+        String resultOK = spy.findResourceById("http://data.brreg.no/datakatalog/katalog/974761076/5",
+                queryString,
+                "text/turtle");
+
+        assertThat(resultOK, not(nullValue()));
+
+        String urlEncodedIdResult = spy.findResourceById("http%3A%2F%2Fdata.brreg.no%2Fdatakatalog%2Fkatalog%2F974761076%2F5",
+                queryString, "text/turtle");
+
+        assertThat(urlEncodedIdResult, not(nullValue()));
+        boolean eq = urlEncodedIdResult.equals(resultOK);
+        assertThat(true, is(eq));
+
+        String resultNOTFOUND = spy.findResourceById("unknownid", queryString, "application/rdf+xml");
+
+        assertThat(resultNOTFOUND, nullValue());
+
+    }
+
+    @Test
+    public void exportDatasetFusekiNotFound() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doReturn(null).when(spy).invokeFusekiQuery(anyString(), anyString(), anyString(), anyString());
+
+        ResponseEntity<String> response = spy.getDatasetDcat("http://data.brreg.no/datakatalog/katalog/974761076/5",
+                null, "application/ld+json");
+
+        assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @Test
+    public void exportCatalogFusekiNotFound() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doReturn(null).when(spy).invokeFusekiQuery(anyString(), anyString(), anyString(), anyString());
+
+        ResponseEntity<String> response = spy.getCatalogDcat("http://data.brreg.no/datakatalog/katalog/974761076/5",
+                null, "application/ld+json");
+
+        assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @Test
+    public void exportIOExceptionSparqlNotFound() throws Throwable {
+        PortalRestController spy = spy(portal);
+
+        ResponseEntity<String> response = spy.invokeFusekiQuery("http://data.brreg.no/datakatalog/katalog/974761076/5",
+                null, "application/ld+json", "sparql/nofile.sparql");
+
+        assertThat(response, nullValue());
+    }
+
+    private static String read(InputStream input) throws IOException {
+        try (BufferedReader buffer = new BufferedReader(new InputStreamReader(input))) {
+            return buffer.lines().collect(Collectors.joining("\n"));
+        }
+    }
+
+}

--- a/portal/webapp/src/test/java/no/dcat/portal/webapp/PortalRestControllerTest.java
+++ b/portal/webapp/src/test/java/no/dcat/portal/webapp/PortalRestControllerTest.java
@@ -208,7 +208,7 @@ public class PortalRestControllerTest {
     }
 
     @Test
-    public void unknownIdReturnsNull() throws Throwable {
+    public void findResourceWithunknownIdReturnsNull() throws Throwable {
         PortalRestController spy = spy(portal);
         Resource mResource = new ClassPathResource("data.ttl");
         org.apache.jena.query.Dataset dataset = RDFDataMgr.loadDataset(mResource.getURL().toString());
@@ -252,13 +252,35 @@ public class PortalRestControllerTest {
     }
 
     @Test
-    public void exportIOExceptionSparqlNotFound() throws Throwable {
+    public void invokeFusekiQueryThrowsExceptionSinceNoSparqlQueryFileIsFound() throws Throwable {
         PortalRestController spy = spy(portal);
 
         ResponseEntity<String> response = spy.invokeFusekiQuery("http://data.brreg.no/datakatalog/katalog/974761076/5",
                 null, "application/ld+json", "sparql/nofile.sparql");
 
         assertThat(response, nullValue());
+    }
+
+
+    @Test
+    public void invokeFusekiQueryThrowsExceptionbecauseOfIOErrorInFuseki() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doThrow(new Exception("force exception")).when(spy).getQueryExecution(anyObject());
+
+        ResponseEntity<String> response = spy.invokeFusekiQuery("http://data.brreg.no/datakatalog/katalog/974761076/5",
+                null, "application/ld+json", "sparql/catalog.sparql");
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
+    }
+
+    @Test
+    public void getCatalogsThrowsExceptionBecauseOfIOErrorInFuseki() throws Throwable {
+        PortalRestController spy = spy(portal);
+        doThrow(new Exception("force exception")).when(spy).getQueryExecution(anyObject());
+
+        ResponseEntity<String> response = spy.getCatalogs("*/*");
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
     }
 
     private static String read(InputStream input) throws IOException {

--- a/portal/webapp/src/test/resources/data-no-catalog.ttl
+++ b/portal/webapp/src/test/resources/data-no-catalog.ttl
@@ -1,0 +1,194 @@
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix fo:    <http://www.w3.org/1999/XSL/Format#> .
+@prefix http:  <http://www.w3.org/2011/http#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcat:  <http://www.w3.org/ns/dcat#> .
+@prefix er:    <http://data.brreg.no/meta/> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/59>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "Detaljert informasjon om skattyters formue, inntekt, gjeld og fradrag"@nb ;
+        dct:identifier          "59" ;
+        dct:landingPage         <https://skatteetaten.github.io/datasamarbeid-api-dokumentasjon/index.html> ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:spatial             <http://sws.geonames.org/3144096/> ;
+        dct:title               "Skattegrunnlag"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-12> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/21> ;
+        dcat:keyword            "formue"@nb , "gjeld og fradrag"@nb , "inntekt"@nb ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/63>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "Informasjon om innrapportert inntekt"@nb ;
+        dct:identifier          "63" ;
+        dct:landingPage         <https://skatteetaten.github.io/datasamarbeid-api-dokumentasjon/index.html> ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:title               "Innrapportert inntekt"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-13> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/26> ;
+        dcat:keyword            "formue"@nb , "grunnlagsdata"@nb , "inntekt"@nb , "gjeld og fradrag"@nb ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/57>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "a-melding per innteksmottaker"@nb ;
+        dct:identifier          "57" ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:spatial             <http://sws.geonames.org/3144096/> ;
+        dct:title               "A-melding per innteksmottaker"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-12> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/19> ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/distribusjon/27>
+        a                dcat:Distribution ;
+        dct:description  "Beregningsgrunnlag Skatteetaten"@nb ;
+        dct:format       "application/xml, application/json" .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/61>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "Informasjon om fordringer Skatteetaten har mot skattyter"@nb ;
+        dct:identifier          "61" ;
+        dct:landingPage         <https://skatteetaten.github.io/datasamarbeid-api-dokumentasjon/index.html> ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:title               "Restanser"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-13> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/24> ;
+        dcat:keyword            "forfalt og ubetalt"@nb , "organisasjonsnummer"@nb , "renter og gebyrer"@nb ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/distribusjon/20>
+        a                dcat:Distribution ;
+        dct:description  "a-melding data per arbeidsgiver"@nb ;
+        dct:format       "text/json, text/xml" ;
+        dcat:accessURL   <http://api.skatteetaten.no/datasamarbeid/arbeidsgiver/version/organisasjonsnummer> .
+
+<http://data.brreg.no/datakatalog/distribusjon/19>
+        a                dcat:Distribution ;
+        dct:description  "a-melding per innteksmottaker"@nb ;
+        dct:format       "text/json, text/xml" ;
+        dcat:accessURL   <http://api.skatteetaten.no/datasamarbeid/inntektsmottaker/version/personidentifkator/inntekt> .
+
+<http://data.brreg.no/datakatalog/kontaktpunkt/a-12>
+        a       <http://www.w3.org/2006/vcard/ns#Organization> ;
+        <http://www.w3.org/2006/vcard/ns#organization-unit>
+                "Skatteetaten" .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/64>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "Overordnet informasjon om skattyters formue og inntekt. Ligger til grunn for selve skatteberegningen"@nb ;
+        dct:identifier          "64" ;
+        dct:landingPage         <https://skatteetaten.github.io/datasamarbeid-api-dokumentasjon/index.html> ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:title               "Beregningsgrunnlag"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-13> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/27> ;
+        dcat:keyword            "skatteberegningsgrunnlag"@nb , "formue"@nb , "inntekt"@nb , "gjeld og fradrag"@nb ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/58>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "a-melding data per arbeidsgiver"@nb ;
+        dct:identifier          "58" ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:spatial             <http://sws.geonames.org/3144096/> ;
+        dct:title               "A-melding data per arbeidsgiver"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-12> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/20> ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/enhetsregisteret/enhet/974761076>
+        a                            foaf:Agent ;
+        er:antallAnsatte             "0" ;
+        er:forretningsadresse        <http://data.brreg.no/enhetsregisteret/enhet/974761076/forretningsadresse> ;
+        er:hjemmeside                "www.skatteetaten.no/" ;
+        er:institusjonellSektorkode  <http://data.brreg.no/enhetsregisteret/enhet/974761076/institusjonellSektorkode> ;
+        er:konkurs                   "N" ;
+        er:naeringskode1             <http://data.brreg.no/enhetsregisteret/enhet/974761076/naeringskode1> ;
+        er:organisasjonsform         "ORGL" ;
+        er:organisasjonsnummer       "974761076" ;
+        er:overordnetEnhet           "972417807" ;
+        er:postadresse               <http://data.brreg.no/enhetsregisteret/enhet/974761076/postadresse> ;
+        er:registreringsdatoEnhetsregisteret
+                "1995-08-09" ;
+        er:registrertIForetaksregisteret
+                "N" ;
+        er:registrertIFrivillighetsregisteret
+                "N" ;
+        er:registrertIMvaregisteret  "J" ;
+        er:registrertIStiftelsesregisteret
+                "N" ;
+        er:underAvvikling            "N" ;
+        er:underTvangsavviklingEllerTvangsopplosning
+                "N" ;
+        dct:identifier               "974761076" ;
+        foaf:name                    "SKATTEETATEN" .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/62>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "Informasjon om skattyters overholdelse av oppgaveplikten"@nb ;
+        dct:identifier          "62" ;
+        dct:landingPage         <https://skatteetaten.github.io/datasamarbeid-api-dokumentasjon/index.html> ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:title               "Oppgaveinnlevering"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-13> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/25> ;
+        dcat:keyword            "mva"@nb ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/distribusjon/21>
+        a                dcat:Distribution ;
+        dct:description  "Skattegrunnlag Skatteetaten"@nb ;
+        dct:format       "application/xml, application/json" ;
+        dcat:accessURL   <http://api.skatteetaten.no/datasamarbeid/skattemelding/skattegrunnlag> .
+
+<http://data.brreg.no/datakatalog/distribusjon/26>
+        a                dcat:Distribution ;
+        dct:description  "Innrapportert inntekt Skatteetaten"@nb ;
+        dct:format       "application/xml, application/json" .
+
+<http://data.brreg.no/datakatalog/kontaktpunkt/a-13>
+        a       <http://www.w3.org/2006/vcard/ns#Organization> ;
+        <http://www.w3.org/2006/vcard/ns#hasEmail>
+                <mailto:brukerstotte.datasamarbeid@skatteetaten.no> ;
+        <http://www.w3.org/2006/vcard/ns#organization-unit>
+                "Skatteetaten, datasamarbeid" .

--- a/portal/webapp/src/test/resources/data.ttl
+++ b/portal/webapp/src/test/resources/data.ttl
@@ -1,0 +1,202 @@
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix fo:    <http://www.w3.org/1999/XSL/Format#> .
+@prefix http:  <http://www.w3.org/2011/http#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcat:  <http://www.w3.org/ns/dcat#> .
+@prefix er:    <http://data.brreg.no/meta/> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/59>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "Detaljert informasjon om skattyters formue, inntekt, gjeld og fradrag"@nb ;
+        dct:identifier          "59" ;
+        dct:landingPage         <https://skatteetaten.github.io/datasamarbeid-api-dokumentasjon/index.html> ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:spatial             <http://sws.geonames.org/3144096/> ;
+        dct:title               "Skattegrunnlag"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-12> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/21> ;
+        dcat:keyword            "formue"@nb , "gjeld og fradrag"@nb , "inntekt"@nb ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/63>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "Informasjon om innrapportert inntekt"@nb ;
+        dct:identifier          "63" ;
+        dct:landingPage         <https://skatteetaten.github.io/datasamarbeid-api-dokumentasjon/index.html> ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:title               "Innrapportert inntekt"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-13> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/26> ;
+        dcat:keyword            "formue"@nb , "grunnlagsdata"@nb , "inntekt"@nb , "gjeld og fradrag"@nb ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/57>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "a-melding per innteksmottaker"@nb ;
+        dct:identifier          "57" ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:spatial             <http://sws.geonames.org/3144096/> ;
+        dct:title               "A-melding per innteksmottaker"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-12> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/19> ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/distribusjon/27>
+        a                dcat:Distribution ;
+        dct:description  "Beregningsgrunnlag Skatteetaten"@nb ;
+        dct:format       "application/xml, application/json" .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/61>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "Informasjon om fordringer Skatteetaten har mot skattyter"@nb ;
+        dct:identifier          "61" ;
+        dct:landingPage         <https://skatteetaten.github.io/datasamarbeid-api-dokumentasjon/index.html> ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:title               "Restanser"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-13> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/24> ;
+        dcat:keyword            "forfalt og ubetalt"@nb , "organisasjonsnummer"@nb , "renter og gebyrer"@nb ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/distribusjon/20>
+        a                dcat:Distribution ;
+        dct:description  "a-melding data per arbeidsgiver"@nb ;
+        dct:format       "text/json, text/xml" ;
+        dcat:accessURL   <http://api.skatteetaten.no/datasamarbeid/arbeidsgiver/version/organisasjonsnummer> .
+
+<http://data.brreg.no/datakatalog/distribusjon/19>
+        a                dcat:Distribution ;
+        dct:description  "a-melding per innteksmottaker"@nb ;
+        dct:format       "text/json, text/xml" ;
+        dcat:accessURL   <http://api.skatteetaten.no/datasamarbeid/inntektsmottaker/version/personidentifkator/inntekt> .
+
+<http://data.brreg.no/datakatalog/katalog/974761076/5>
+        a                dcat:Catalog ;
+        dct:description  "Katalog over datasett i Skatteetaten"@nb ;
+        dct:publisher    <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:title        "Skatteetaten datakatalog"@nb ;
+        dcat:dataset     <http://data.brreg.no/datakatalog/dataset/974761076/63> , <http://data.brreg.no/datakatalog/dataset/974761076/62> , <http://data.brreg.no/datakatalog/dataset/974761076/58> , <http://data.brreg.no/datakatalog/dataset/974761076/57> , <http://data.brreg.no/datakatalog/dataset/974761076/61> , <http://data.brreg.no/datakatalog/dataset/974761076/56> , <http://data.brreg.no/datakatalog/dataset/974761076/55> , <http://data.brreg.no/datakatalog/dataset/974761076/32> , <http://data.brreg.no/datakatalog/dataset/974761076/31> , <http://data.brreg.no/datakatalog/dataset/974761076/64> , <http://data.brreg.no/datakatalog/dataset/974761076/59> ;
+        foaf:homepage    <http://www.skatteetaten.no> .
+
+<http://data.brreg.no/datakatalog/kontaktpunkt/a-12>
+        a       <http://www.w3.org/2006/vcard/ns#Organization> ;
+        <http://www.w3.org/2006/vcard/ns#organization-unit>
+                "Skatteetaten" .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/64>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "Overordnet informasjon om skattyters formue og inntekt. Ligger til grunn for selve skatteberegningen"@nb ;
+        dct:identifier          "64" ;
+        dct:landingPage         <https://skatteetaten.github.io/datasamarbeid-api-dokumentasjon/index.html> ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:title               "Beregningsgrunnlag"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-13> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/27> ;
+        dcat:keyword            "skatteberegningsgrunnlag"@nb , "formue"@nb , "inntekt"@nb , "gjeld og fradrag"@nb ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/58>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "a-melding data per arbeidsgiver"@nb ;
+        dct:identifier          "58" ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:spatial             <http://sws.geonames.org/3144096/> ;
+        dct:title               "A-melding data per arbeidsgiver"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-12> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/20> ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/enhetsregisteret/enhet/974761076>
+        a                            foaf:Agent ;
+        er:antallAnsatte             "0" ;
+        er:forretningsadresse        <http://data.brreg.no/enhetsregisteret/enhet/974761076/forretningsadresse> ;
+        er:hjemmeside                "www.skatteetaten.no/" ;
+        er:institusjonellSektorkode  <http://data.brreg.no/enhetsregisteret/enhet/974761076/institusjonellSektorkode> ;
+        er:konkurs                   "N" ;
+        er:naeringskode1             <http://data.brreg.no/enhetsregisteret/enhet/974761076/naeringskode1> ;
+        er:organisasjonsform         "ORGL" ;
+        er:organisasjonsnummer       "974761076" ;
+        er:overordnetEnhet           "972417807" ;
+        er:postadresse               <http://data.brreg.no/enhetsregisteret/enhet/974761076/postadresse> ;
+        er:registreringsdatoEnhetsregisteret
+                "1995-08-09" ;
+        er:registrertIForetaksregisteret
+                "N" ;
+        er:registrertIFrivillighetsregisteret
+                "N" ;
+        er:registrertIMvaregisteret  "J" ;
+        er:registrertIStiftelsesregisteret
+                "N" ;
+        er:underAvvikling            "N" ;
+        er:underTvangsavviklingEllerTvangsopplosning
+                "N" ;
+        dct:identifier               "974761076" ;
+        foaf:name                    "SKATTEETATEN" .
+
+<http://data.brreg.no/datakatalog/dataset/974761076/62>
+        a                       dcat:Dataset ;
+        <http://difi.no/dcatno#accessRightsComment>
+                <https://lovdata.no/NL/lov/2016-05-27-14/§3-1> ;
+        dct:accessRights        <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+        dct:accrualPeriodicity  <http://publications.europa.eu/resource/authority/frequency/CONT> ;
+        dct:description         "Informasjon om skattyters overholdelse av oppgaveplikten"@nb ;
+        dct:identifier          "62" ;
+        dct:landingPage         <https://skatteetaten.github.io/datasamarbeid-api-dokumentasjon/index.html> ;
+        dct:language            <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:publisher           <http://data.brreg.no/enhetsregisteret/enhet/974761076> ;
+        dct:title               "Oppgaveinnlevering"@nb ;
+        dcat:contactPoint       <http://data.brreg.no/datakatalog/kontaktpunkt/a-13> ;
+        dcat:distribution       <http://data.brreg.no/datakatalog/distribusjon/25> ;
+        dcat:keyword            "mva"@nb ;
+        dcat:theme              <http://publications.europa.eu/resource/authority/data-theme/GOVE> .
+
+<http://data.brreg.no/datakatalog/distribusjon/21>
+        a                dcat:Distribution ;
+        dct:description  "Skattegrunnlag Skatteetaten"@nb ;
+        dct:format       "application/xml, application/json" ;
+        dcat:accessURL   <http://api.skatteetaten.no/datasamarbeid/skattemelding/skattegrunnlag> .
+
+<http://data.brreg.no/datakatalog/distribusjon/26>
+        a                dcat:Distribution ;
+        dct:description  "Innrapportert inntekt Skatteetaten"@nb ;
+        dct:format       "application/xml, application/json" .
+
+<http://data.brreg.no/datakatalog/kontaktpunkt/a-13>
+        a       <http://www.w3.org/2006/vcard/ns#Organization> ;
+        <http://www.w3.org/2006/vcard/ns#hasEmail>
+                <mailto:brukerstotte.datasamarbeid@skatteetaten.no> ;
+        <http://www.w3.org/2006/vcard/ns#organization-unit>
+                "Skatteetaten, datasamarbeid" .

--- a/portal/webapp/src/test/resources/logback-test.xml
+++ b/portal/webapp/src/test/resources/logback-test.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="org.springframework.web" level="WARN"/>
+    <logger name="org.apache.http.wire" level="WARN"/>
+    <logger name="org.apache.jena" level="ERROR"/>
+	<logger name="no.difi.dcat" level="TRACE" />
+    <logger name="no.dcat" level="TRACE" />
+</configuration>


### PR DESCRIPTION
Har jobbet med apiet og sparql spørringer for å eksportere datasett og hele kataloger fra fuseki. 
- /dataset?id=dataset-uri&format=ttl (støtter også acceptheaders text/turtle, application/ld+json, application/rdf+xml. Denne burde være /datasets, men fant ikke helt ut hvordan jeg kunne kombinere to restkontroller som begge leverte /datasets.

- /catalogs returnerer en html side med alle katalogene. Denne er midlertidig siden vi ikke har gui for å få ut katalogideene.

- /catalogs?id=catalog-uri=format=ttl (støtter også acceptheader text/turtle, application/ld+json, application/rdf+xml.