### PR TITLE
Bugfix/fix e2e tests login

### DIFF
--- a/registrering-gui/e2e/app.e2e-spec.ts
+++ b/registrering-gui/e2e/app.e2e-spec.ts
@@ -22,6 +22,26 @@ describe('registrering-gui App', () => {
     });
 
     beforeAll(() => {
+        //create test dataset
+        page = new RegistreringGuiPage();
+        browser.get("/")
+        element(by.buttonText("Logg inn som bjg")).isPresent().then(function (isPresent) {
+            if (isPresent) {
+                let submitButton = element(by.buttonText("Logg inn som bjg"));
+                submitButton.click();
+            }
+        });
+
+        var isLoggedInElement = element(by.css('.alert-success'));
+        var EC = protractor.ExpectedConditions;
+        browser.wait(EC.presenceOf(isLoggedInElement), 10000);
+
+        let catalogLink = element(by.css("#datacatalogs td"));
+        catalogLink.click();
+
+        let newDatasetLink = element(by.buttonText("Nytt datasett"));
+        newDatasetLink.click();
+
     });
 
     it("should save conformsTo uris", () => {


### PR DESCRIPTION
Fikset feil i e2e-test for registrering-gui:
* Tidligere feilet testen hivs det ikke fantes minst ett datasett fra før. Nå oppretter testen et datasett før den begynner å kjøre
* Fikset en test som feilet pga at vi nå har en ekstra verdi for opphav ("Tredjepart")

Det er to tester som feiler pga at gui for språk og valg av dato er endret.
Har laget en Jira-sak på denne: FDK-537. Den på nesten Frederic ta når han er tilbake.