### PR TITLE
fixed merge errors in application.yml

### DIFF
--- a/applications/registration-api/src/main/resources/application.yml
+++ b/applications/registration-api/src/main/resources/application.yml
@@ -1,8 +1,8 @@
-
 application:
+  catalogUriPrefix: http://localhost:8099
   themesServiceUrl: http://localhost:8100
   apikey: ${registrationApi_apikey:12345-ABCDE-67890-FGHIJ}
-  altinnServiceUrl: ${registrationApi_altinnServiceUrl:http://registration-auth:8080}
+  altinnServiceUrl: ${registrationApi_altinnServiceUrl:http://localhost:8077}
   altinnServiceCode: ${registrationApi_altinnServiceCode:4814}
   altinnServiceEdition: ${registrationApi_altinnServiceEdition:3}
   clientSSLCertificateKeystoreLocation: ${registrationApi_clientSSLCertificateKeystoreLocation:conf/dummy-client-SSL-cert.p12}
@@ -107,10 +107,6 @@ server:
     key-store-password: changeit
     key-store-type: PKCS12
     key-alias: tomcat
-application:
-  altinnServiceUrl: http://localhost:8077
-
-
 
 ---
 spring:
@@ -129,11 +125,3 @@ application:
   altinnServiceCode: 1234
   altinnServiceEdition: 42
   apiKey: 1234-abcde-56789-fghij
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Ved forrige gangs merge av id-porten/openshift konfigurasjon, har det trolig skjedd en feil i mergen, som gjorde at application.yml ikke var riktig. Dette gjorde at applikasjonen feilet på de miljøene som gikk mot id-porten.

I denne fiksen er application.yml for registration-api kopiert fra branch feature/openshift-setup.
Har bygd og deployet denne branchen på st1 og sett at det fungerer.


<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ x] This code does not require tests that match user stories
