### PR TITLE
Feature/deployscript autocreate imagestreams

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -24,7 +24,7 @@ git fetch --tags
 
 DATETIME=`date "+%Y-%m-%dT%H_%M_%S"`
 
-#docker login --username ${dockerUsername} --password ${dockerPassword}
+docker login --username ${dockerUsername} --password ${dockerPassword}
 
 function dockerTag {
   component=$1
@@ -86,8 +86,6 @@ if [ "$1" == "st1" ] ; then
 
   gitTag ut1 st1
 
-  #todo dobbeltsjekk at dockertag blir riktig
-#  openshiftDeploy st1 ${toEnvironment}_${DATETIME}
 
 elif [ "$1" == "st2" ] ; then
 
@@ -97,9 +95,6 @@ elif [ "$1" == "st2" ] ; then
   done
 
   gitTag ut1 st2
-
-  #todo dobbeltsjekk at dockertag blir riktig
-#  openshiftDeploy st2 ${toEnvironment}_${DATETIME}
 
 
 elif [ "$1" == "tt1" ] ; then
@@ -111,8 +106,6 @@ elif [ "$1" == "tt1" ] ; then
 
   gitTag st2 tt1
 
-#  openshiftDeploy tt1 ${toEnvironment}_${DATETIME}
-
 
 elif [ "$1" == "ppe" ] ; then
   for i in $components
@@ -122,7 +115,6 @@ elif [ "$1" == "ppe" ] ; then
 
   gitTag st1 ppe
 
-#  openshiftDeploy ppe ${toEnvironment}_${DATETIME}
 
 
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,7 +14,7 @@ if [ "${GIT_STATUS}" != "Your branch is up-to-date with 'origin/develop'." ] ; t
   exit;
 fi
 
-components="fuseki harvester harvester-api nginx reference-data registration registration-api registration-auth registration-validator search search-api"
+components="fuseki harvester harvester-api nginx nginx-search reference-data registration registration-api registration-auth registration-validator search search-old search-api"
 
 
 # remove all local tags
@@ -24,7 +24,7 @@ git fetch --tags
 
 DATETIME=`date "+%Y-%m-%dT%H_%M_%S"`
 
-docker login --username ${dockerUsername} --password ${dockerPassword}
+#docker login --username ${dockerUsername} --password ${dockerPassword}
 
 function dockerTag {
   component=$1

--- a/runCreateServiceInOpenshift.sh
+++ b/runCreateServiceInOpenshift.sh
@@ -14,8 +14,6 @@
 # example:
 # runCreateServiceInOpenshift registration-api st2 latest st2_2017-02-18 recreateServices
 
-# todo sjekk at riktig profil brukes på miljøene som ikke skal ha idport ingetrasjon prod-localauth
-
 function createOpenshiftService {
     osService=$1
 
@@ -29,6 +27,8 @@ function createOpenshiftService {
         environmentTag=$environmentTag \
         environmentDate=$dateTag
 
+    #tag the image stream to auto-pull new images from docker hub
+    oc tag --scheduled=true docker.io/dcatno/$osService:$tag $osService:$tag
 }
 
 function deployNewDockerImage {
@@ -58,28 +58,28 @@ function exposeService {
 if [ -z "$1" ]
 then
     echo "service must be specified: search, registration, search-api etc..."
-    echo "correct usage: runCreateServiceInOpenshift.sh <service> <environment> <dockertag> <date-tag>"
+    echo "correct usage: runCreateServiceInOpenshift.sh <service> <environment> <dockertag> <date-tag> <deploymode>"
     exit 1
 fi
 
 if [ -z "$2" ]
 then
     echo "environment must be specified: ut1, st1, st2, tt1 ppe or prd"
-    echo "correct usage: runCreateServiceInOpenshift.sh <service> <environment> <dockertag> <date-tag>"
+    echo "correct usage: runCreateServiceInOpenshift.sh <service> <environment> <dockertag> <date-tag> <deploymode>"
     exit 1
 fi
 
 if [ -z "$3" ]
 then
     echo "docker  tag must be supplied. Example: latest"
-    echo "correct usage: runCreateServiceInOpenshift.sh <service> <environment> <dockertag> <date-tag>"
+    echo "correct usage: runCreateServiceInOpenshift.sh <service> <environment> <dockertag> <date-tag> <deploymode>"
     exit 1
 fi
 
 if [ -z "$4" ]
 then
     echo "Environment date tag must be supplied. Example: ST1_2017-09-13"
-    echo "correct usage: runCreateServiceInOpenshift.sh <service> <environment> <dockertag>  <date-tag>"
+    echo "correct usage: runCreateServiceInOpenshift.sh <service> <environment> <dockertag>  <date-tag> <deploymode>"
     exit 1
 fi
 

--- a/runCreateServiceInOpenshift.sh
+++ b/runCreateServiceInOpenshift.sh
@@ -14,6 +14,7 @@
 # example:
 # runCreateServiceInOpenshift registration-api st2 latest st2_2017-02-18 recreateServices
 
+# todo sjekk at riktig profil brukes på miljøene som ikke skal ha idport ingetrasjon prod-localauth
 
 function createOpenshiftService {
     osService=$1
@@ -23,8 +24,9 @@ function createOpenshiftService {
     oc env dc/$osService SPRING_PROFILES_ACTIVE=$profile JVM_OPTIONS="-Xms128m -Xmx256m"
     oc label service $osService --overwrite=true \
         environmentTag=$environmentTag \
+        environmentDate=$dateTag
+    oc label dc $osService --overwrite=true \
         environmentTag=$environmentTag \
-        environmentDate=$dateTag \
         environmentDate=$dateTag
 
 }
@@ -36,8 +38,9 @@ function deployNewDockerImage {
 
     oc label service $osService --overwrite=true \
         environmentTag=$environmentTag \
+        environmentDate=$dateTag
+    oc label dc $osService --overwrite=true \
         environmentTag=$environmentTag \
-        environmentDate=$dateTag \
         environmentDate=$dateTag
 
 }

--- a/runDeleteServicesInOpenshift.sh
+++ b/runDeleteServicesInOpenshift.sh
@@ -12,7 +12,7 @@ profile=fellesdatakatalog-$environment
 tag=latest
 
 #midlertidig kommentert ut reference-data
-services="registration registration-auth registration-api registration-validator nginx gdoc harvester harvester-api search search-api"
+services="registration registration-auth registration-api registration-validator nginx nginx-search gdoc harvester harvester-api search search-old search-api"
 
 for i in $services
 do


### PR DESCRIPTION
Et par små fikser i deployscript for å opprette tjenester:
* Imagestreams som "lytter" på endringer i Docker hub opprettes nå automatisk
* Lagt inn de nye tjenestene search-old og nginx-search også i slettescript

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [x ] This code does not require tests that match user stories
