### PR TITLE
Added routes to api for harvest in nginx, allowed anonymous get on /c…

### DIFF
--- a/applications/nginx/src/main/docker/nginx.conf
+++ b/applications/nginx/src/main/docker/nginx.conf
@@ -8,6 +8,9 @@ http {
         default http://registration:4200;
         "~*text/html"   http://registration:4200;
         "~*application/json" http://registration-api:8080;
+        "~*text/turtle" http://registration-api:8080;
+        "~*application/ld+json" http://registration-api:8080;
+        "~*application/rdf+xml" http://registration-api:8080;
     }
 
     server {

--- a/applications/registration-api/src/main/java/no/dcat/config/BasicAuthConfig.java
+++ b/applications/registration-api/src/main/java/no/dcat/config/BasicAuthConfig.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -130,11 +131,11 @@ public class BasicAuthConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/innloggetBruker").permitAll()
                 .antMatchers("/login").permitAll()
                 .antMatchers("/health").permitAll()
-
+                .antMatchers(HttpMethod.GET,"/catalogs/**").permitAll()
 
                 .and()
                 .authorizeRequests()
-                //.antMatchers(HttpMethod.GET,"/catalogs/**").permitAll()
+
                 .anyRequest().authenticated()
                 .and()
                 .formLogin()

--- a/applications/registration-api/src/main/java/no/dcat/rdf/DcatBuilder.java
+++ b/applications/registration-api/src/main/java/no/dcat/rdf/DcatBuilder.java
@@ -300,7 +300,7 @@ public class DcatBuilder {
     }
 
     public DcatBuilder addProperty(Resource resource, Property property, SkosCode code) {
-        if (code != null) {
+        if (code != null && code.getUri() != null && !"".equals(code.getUri())) {
             Resource r = model.createResource(code.getUri());
             resource.addProperty(property, r);
         }
@@ -329,7 +329,9 @@ public class DcatBuilder {
             try {
                 Method m = objectWithUri.getClass().getMethod("getUri");
                 String uri = (String) m.invoke(objectWithUri);
-                addProperty(resource, property, uri);
+                if (!"".equals(uri)) {
+                    addProperty(resource, property, uri);
+                }
             } catch (Exception e) {
                 logger.error("Unable to add URI to {}", property.getLocalName(), e);
             }
@@ -358,7 +360,7 @@ public class DcatBuilder {
     }
 
     public DcatBuilder addProperty(Resource resource, Property property, String uri) {
-        if (uri != null) {
+        if (uri != null && !"".equals(uri)) {
             Resource r = model.createResource(uri);
             resource.addProperty(property, r);
         }

--- a/applications/registration-api/src/main/resources/application.yml
+++ b/applications/registration-api/src/main/resources/application.yml
@@ -52,11 +52,11 @@ spring:
       clusterName: fellesdatakatalog
 logging:
   level.: ERROR
-  level.no.brreg: DEBUG
-  level.no.dcat: DEBUG
+  level.no.brreg: INFO
+  level.no.dcat: INFO
   level.org.springframework: INFO
-  level.org.springframework.web: WARN
-  level.org.opensaml: DEBUG
+  level.org.springframework.web: ERROR
+  level.org.opensaml: INFO
 health:
   config:
     enabled: false

--- a/applications/registration-api/src/main/resources/logback.xml
+++ b/applications/registration-api/src/main/resources/logback.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
-    <logger name="org.springframework.web" level="ERROR"/>
+    <logger name="org.springframework.web" level="DEBUG"/>
     <logger name="org.apache.http.wire" level="ERROR"/>
 
     <logger name="org.apache.jena" level="ERROR"/>
 	<logger name="org.elasticsearch" level ="WARN"/>
 	<logger name="no.difi.dcat" level ="INFO"/>
 
-	<logger name="no.dcat" level="INFO"/>
+	<logger name="no.dcat" level="DEBUG"/>
 
 </configuration>


### PR DESCRIPTION
https://jira.brreg.no/browse/FDK-730

Har fikset nginx til å rute til apiet når /catalogs /xyz for accept headeres text/turtle, application/ld+json og application/rdf+xml. 

Har også kommentert inn igjen kode for å tillate anonymous GET mot /catalogs. 
Har testet lokalt, men ikke mot idporten.

Har ikke lagt til nye tester.
