### PR TITLE
If entity information cannot be retrieved from Enhetsregisteret, the …

### DIFF
--- a/applications/registration-api/src/main/java/no/dcat/authorization/OpenDataAuthorizedOrgformService.java
+++ b/applications/registration-api/src/main/java/no/dcat/authorization/OpenDataAuthorizedOrgformService.java
@@ -34,11 +34,16 @@ public class OpenDataAuthorizedOrgformService implements AuthorizedOrgformServic
         ResponseEntity<OpenDataEnhet> response = new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             response = restTemplate.getForEntity(openDataEnhetsregisteret + entry.getOrganizationNumber(), OpenDataEnhet.class);
+            return response.getStatusCode().is2xxSuccessful() && isAuthorisedOrganisation(response.getBody());
         } catch (RuntimeException rte) {
             logger.warn("Error in getting entity from {} on {}", openDataEnhetsregisteret, entry.getOrganizationNumber());
             logger.warn("Actual error", rte);
+
+            //if enhetsregisteret webservice is unavailable, include organisation
+            //todo: should be handled better
+            logger.info("including entity {} due to missing response from Enhetsregisteret web service", entry.getOrganizationNumber());
+            return true;
         }
-        return response.getStatusCode().is2xxSuccessful() && isAuthorisedOrganisation(response.getBody());
     }
 
     private boolean isAuthorisedOrganisation(OpenDataEnhet enhet) {

--- a/applications/registration-api/src/main/java/no/dcat/config/MyServiceProviderConfig.java
+++ b/applications/registration-api/src/main/java/no/dcat/config/MyServiceProviderConfig.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;

--- a/applications/registration-api/src/test/java/no/dcat/authorization/OpenDataAuthorizedOrgformServiceTest.java
+++ b/applications/registration-api/src/test/java/no/dcat/authorization/OpenDataAuthorizedOrgformServiceTest.java
@@ -77,13 +77,13 @@ public class OpenDataAuthorizedOrgformServiceTest {
     }
 
     @Test
-    public void isIncluded_serviceFailed_shouldNotBeIncluded() throws Exception {
+    public void isIncluded_serviceFailed_shouldBeIncluded() throws Exception {
         when(restTemplate.getForEntity("data.brreg.no/enheter/980123333", OpenDataEnhet.class)).thenThrow(new RuntimeErrorException(new Error()));
 
         Entity entity = new Entity();
         entity.setOrganizationNumber("980123333");
 
-        assertThat(orgformService.isIncluded(entity), is(false));
+        assertThat(orgformService.isIncluded(entity), is(true));
     }
 
 }


### PR DESCRIPTION
Fikset koden, slik at organisasjonen blir godtatt hvis den ikke kan slås opp mot Enhetsregisteret.
Dette er nødvendig for at applikasjonen skal kunne testes mot IDporten testmiljø, der det er fiktive organisasjoner som ikke kan slås opp i Enhetsregisteret åpne data.

<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/FDK-698

> check applicable boxes

- [ x] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
