### PR TITLE
fixed bug in deploy script: no error message dispalayed when local gi…

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,7 @@ set -e
 
 git fetch
 
-GIT_STATUS=`git status | grep "Your branch is up-to-date with"`
+GIT_STATUS=`git status | grep "Your branch is"`
 if [ "${GIT_STATUS}" != "Your branch is up-to-date with 'origin/develop'." ] ; then
   echo "You need to be on origin/develop and be up to date with origin";
   exit;


### PR DESCRIPTION
Fikset feil i deploy-script, som gjorde at scriptet avsluttet uten feilmelding hvis lokalt git-repository ikke var oppdatert i forhold til origin (github). 

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ x] This code does not require tests that match user stories
