### PR TITLE
run integration and e2e tests only during nightly cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,17 +43,19 @@ jobs:
       env:
         - comment=Run regular unit tests
 
-    #- stage: Tests # Run unit and intergation tests + generate test coverage report
-    #  script: mvn install -DskipTests -Dmaven.javadoc.skip=true -B && docker-compose up -d  && ./waitForDocker.sh  &&  mvn verify -DskipDockerBuild -B -P all-tests org.jacoco:jacoco-maven-plugin:report
-    #  after_success:
-    #    - mvn org.eluder.coveralls:coveralls-maven-plugin:report
-    #  env:
-    #    - comment=Run unit and intergation tests + generate test coverage report
+    - stage: Tests # Run unit and intergation tests + generate test coverage report
+      if: type = cron #run only during nightly cron job - time-consuming operation
+      script: mvn install -DskipTests -Dmaven.javadoc.skip=true -B && docker-compose up -d  && ./waitForDocker.sh  &&  mvn verify -DskipDockerBuild -B -P all-tests org.jacoco:jacoco-maven-plugin:report
+      after_success:
+        - mvn org.eluder.coveralls:coveralls-maven-plugin:report
+      env:
+        - comment=Run unit and intergation tests + generate test coverage report
 
-    #- stage: Tests # Run Angular e2e tests
-     # script: mvn install -DskipTests -Dmaven.javadoc.skip=true -B && docker-compose up -d  && ./waitForDocker.sh &&  ./runNodeTests.sh
-      #env:
-       # - comment=Run Angular e2e tests
+    - stage: Tests # Run Angular e2e tests
+      if: type = cron #run only during nightly cron job - time-consuming operation
+      script: mvn install -DskipTests -Dmaven.javadoc.skip=true -B && docker-compose up -d  && ./waitForDocker.sh &&  ./runNodeTests.sh
+      env:
+        - comment=Run Angular e2e tests
 
     - stage: deploy
       script: mvn install -DskipTests -Dmaven.javadoc.skip=true -B ;


### PR DESCRIPTION
Har satt opp en cron-jobb i Travis som bygger develop en gang i døgnet, og endret .travis.yml slik at integrasjonstestene og e2e-testene kun kjører i cron-jobben.

Dessverre lar Travis ikke oss styre hvilket klokkeslett cron-jobben kjører på, kun intervallet mellom hver kjøring. Vi kan derfor ikke tvinge den til å kjøre om natta.

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ x] This code does not require tests that match user stories
