### PR TITLE
Hotfix/same publisher occurs multiple times

### DIFF
--- a/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultPubHandler.java
+++ b/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultPubHandler.java
@@ -18,6 +18,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Class for loading the complete publisher-hieararchi.
@@ -118,6 +120,19 @@ public class ElasticSearchResultPubHandler implements CrawlerResultHandler {
     }
 
     protected IndexRequest addPublisherToIndex(Gson gson, Publisher publisher) {
+        if (publisher.getId() == null) {
+            Pattern p = Pattern.compile("(enhetsregisteret/enhet/)(\\d+)");
+            Matcher m = p.matcher(publisher.getUri());
+
+            if (m.find()) {
+                publisher.setId(m.group(2));
+            }
+        }
+
+        if (publisher.getId() == null) {
+            publisher.setId(publisher.getUri());
+        }
+
         logger.debug("Add publisher {} to index.", publisher.getId());
 
         IndexRequest indexRequest = new IndexRequest(DCAT, PUBLISHER_TYPE, publisher.getId());

--- a/applications/harvester-api/src/test/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultPubHandlerTest.java
+++ b/applications/harvester-api/src/test/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultPubHandlerTest.java
@@ -4,11 +4,13 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import no.dcat.datastore.domain.dcat.Publisher;
 import org.elasticsearch.action.index.IndexRequest;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -17,12 +19,18 @@ import static org.junit.Assert.assertThat;
 public class ElasticSearchResultPubHandlerTest {
     private static Logger logger = LoggerFactory.getLogger(ElasticSearchResultPubHandlerTest.class);
 
-    private static String expected = "index {[dcat][publisher][983887457], source[{\n  \"overordnetEnhet\": \"814716872\",\n  \"organisasjonsform\": \"ORGL\",\n  \"valid\": false,\n  \"uri\": \"http://data.brreg.no/enhetsregisteret/enhet/983887457\",\n  \"id\": \"983887457\",\n  \"name\": \"BR\"\n}]}";
+
+    Gson gson;
+    ElasticSearchResultPubHandler handler;
+
+    @Before
+    public void setup() {
+        gson = new GsonBuilder().setPrettyPrinting().setDateFormat("yyyy-MM-dd'T'HH:mm:ssX").create();
+        handler = new ElasticSearchResultPubHandler(null, 0, null);
+    }
 
     @Test
     public void addPublisherToIndexOK() {
-        Gson gson = new GsonBuilder().setPrettyPrinting().setDateFormat("yyyy-MM-dd'T'HH:mm:ssX").create();
-        ElasticSearchResultPubHandler handler = new ElasticSearchResultPubHandler(null, 0, null);
 
         String pudlisherUri = "http://data.brreg.no/enhetsregisteret/enhet/983887457";
         String organisasjonsform    = "ORGL";
@@ -36,9 +44,39 @@ public class ElasticSearchResultPubHandlerTest {
         publisher.setUri(pudlisherUri);
         publisher.setId("983887457");
 
+        final String expected = "index {[dcat][publisher][983887457], source[{\n  \"overordnetEnhet\": \"814716872\",\n  \"organisasjonsform\": \"ORGL\",\n  \"valid\": false,\n  \"uri\": \"http://data.brreg.no/enhetsregisteret/enhet/983887457\",\n  \"id\": \"983887457\",\n  \"name\": \"BR\"\n}]}";
+
+
         IndexRequest actual = handler.addPublisherToIndex(gson, publisher);
 
         assertThat(actual.toString(), is(expected));
+    }
+
+    @Test
+    public void addPublisherWithoutId() {
+        Publisher publisher = new Publisher();
+        publisher.setOrganisasjonsform("ORGL");
+        publisher.setUri("http://data.brreg.no/enhetsregisteret/enhet/983887457");
+
+        final String expected = "index {[dcat][publisher][983887457], source[{\n  \"organisasjonsform\": \"ORGL\",\n  \"valid\": false,\n  \"uri\": \"http://data.brreg.no/enhetsregisteret/enhet/983887457\",\n  \"id\": \"983887457\"\n}]}";
+
+        assertThat(publisher.getId(), is(nullValue()));
+
+        IndexRequest actual = handler.addPublisherToIndex(gson, publisher);
+
+        assertThat(publisher.getId(), is( "983887457"));
+        assertThat(actual.toString(), is (expected));
+    }
+
+    @Test
+    public void addPublisherWithoutOrgNumberInUri() {
+        Publisher publisher = new Publisher();
+        publisher.setOrganisasjonsform("ORGL");
+        publisher.setUri("http://some/other/uri");
+
+        IndexRequest actual = handler.addPublisherToIndex(gson, publisher);
+
+        assertThat(publisher.getId(), is("http://some/other/uri"));
     }
 
 

--- a/applications/search/src/components/search-results-dataset-report-stats/index.jsx
+++ b/applications/search/src/components/search-results-dataset-report-stats/index.jsx
@@ -15,7 +15,7 @@ const ReportStats = (props) => {
     restricted: (aggregateDataset.aggregations && aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'RESTRICTED')) ?
       aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'RESTRICTED').doc_count : 0,
     nonPublic: (aggregateDataset.aggregations && aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'NONPUBLIC')) ?
-      aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'NONPUBLIC').doc_count : 0,
+      aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'NON_PUBLIC').doc_count : 0,
     unknown: (aggregateDataset.aggregations && aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'UKJENT')) ?
       aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'UKJENT').doc_count : 0,
     newLastWeek: 0,

--- a/applications/search/src/components/search-results-dataset-report-stats/index.jsx
+++ b/applications/search/src/components/search-results-dataset-report-stats/index.jsx
@@ -14,7 +14,7 @@ const ReportStats = (props) => {
       aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'PUBLIC').doc_count : 0,
     restricted: (aggregateDataset.aggregations && aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'RESTRICTED')) ?
       aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'RESTRICTED').doc_count : 0,
-    nonPublic: (aggregateDataset.aggregations && aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'NONPUBLIC')) ?
+    nonPublic: (aggregateDataset.aggregations && aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'NON_PUBLIC')) ?
       aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'NON_PUBLIC').doc_count : 0,
     unknown: (aggregateDataset.aggregations && aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'UKJENT')) ?
       aggregateDataset.aggregations.accessRightsCount.buckets.find(bucket => bucket.key.toUpperCase() === 'UKJENT').doc_count : 0,


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->

https://jira.brreg.no/browse/FDK-964

Publisher får nå følgende index id i elastic:
- Publishere som ikke er gyldige eller funnet i enhetsregisteret fikk id som null. Dette førte til at Elastic laget nye identifikatorer på publisherene.
- Har laget rutine for å ekstrahere orgnummer fra uri og bruk av uri som fallback
- Laget tester for de to tilfellene

https://jira.brreg.no/browse/FDK-965
- Endret kode fra NONPUBLIC to NON_PUBLIC

> check applicable boxes

- [x] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
