### PR TITLE
Feature/lenker uten protokoll

### DIFF
--- a/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/CrawlerJob.java
+++ b/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/CrawlerJob.java
@@ -203,7 +203,6 @@ public class CrawlerJob implements Runnable {
         }
 
         // remember the base url
-
         Resource o = ResourceFactory.createResource(url.toString());
         union.add(DCATCrawler.ImportResource, DCATCrawler.source_url, o);
 
@@ -211,13 +210,11 @@ public class CrawlerJob implements Runnable {
 
         //Enrich model with elements missing according to DCAT-AP-NO 1.1 standard
         DataEnricher enricher = new DataEnricher();
-        Model enrichedUnion = enricher.enrichData(union);
-        union = enrichedUnion;
+        union = enricher.enrichData(union);
 
         // Checks subjects and resolve definitions
         if (subjectCrawler != null) {
-            Model modelWithSubjects = subjectCrawler.annotateSubjects(union);
-            union = modelWithSubjects;
+            union = subjectCrawler.annotateSubjects(union);
         } else {
             logger.warn("Could not annotate subjects. Reason subject crawler is not initialized!");
         }
@@ -225,7 +222,6 @@ public class CrawlerJob implements Runnable {
         // Checks publisher and resolve according to registrered in BRREG Enhetsregistret
         BrregAgentConverter brregAgentConverter = new BrregAgentConverter(brregCache);
         brregAgentConverter.collectFromModel(union);
-
 
         return union;
     }
@@ -342,7 +338,7 @@ public class CrawlerJob implements Runnable {
      * Remove non-valida datasets from model
      * Non-valid datasets are those with ruleSeverity=error
      * in global variable validationErrors
-     * @param model
+     * @param model the model containing the resources to be removed
      */
     private void removeNonValidDatasets(Model model) {
 
@@ -361,7 +357,7 @@ public class CrawlerJob implements Runnable {
     /**
      * Remove triples containing DCTerms.spatial URLs that cannot be resolved
      *
-     * @param model
+     * @param model the model
      */
     private String removeNonResolvableLocations(Model model) {
         StringBuilder resultMsg = new StringBuilder();

--- a/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandler.java
+++ b/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandler.java
@@ -19,6 +19,8 @@ import no.dcat.datastore.domain.dcat.vocabulary.DCAT;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.RDF;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
@@ -156,7 +158,7 @@ public class ElasticSearchResultHandler implements CrawlerResultHandler {
             }
 
             catalogRecord.setNonValidDatasetUris(new HashSet<>());
-            catalogRecord.getNonValidDatasetUris().addAll(datasetsInSource);
+            catalogRecord.getNonValidDatasetUris().addAll(getDatasetsUris(model, catalog.getUri()));
             catalogRecord.getNonValidDatasetUris().removeAll(catalogRecord.getValidDatasetUris());
 
             deletePreviousDatasetsNotPresentInThisHarvest(elasticsearch, gson, catalogRecord, stats);
@@ -174,7 +176,8 @@ public class ElasticSearchResultHandler implements CrawlerResultHandler {
 
     }
 
-    private void deletePreviousDatasetsNotPresentInThisHarvest(Elasticsearch elasticsearch, Gson gson, CatalogHarvestRecord thisCatalogRecord, ChangeInformation stats) {
+    private void deletePreviousDatasetsNotPresentInThisHarvest(Elasticsearch elasticsearch, Gson gson,
+                                                               CatalogHarvestRecord thisCatalogRecord, ChangeInformation stats) {
 
         TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery("catalogUri", thisCatalogRecord.getCatalogUri());
         ConstantScoreQueryBuilder csQueryBuilder = QueryBuilders.constantScoreQuery(termQueryBuilder);
@@ -219,6 +222,17 @@ public class ElasticSearchResultHandler implements CrawlerResultHandler {
             datasetsInSource.add(r.getURI());
         }
         return datasetsInSource;
+    }
+
+    Set<String> getDatasetsUris(Model model, String catalogUri) {
+        Set<String> datasetsInCatalog = new HashSet<>();
+        Resource catalogResource = model.getResource(catalogUri);
+        StmtIterator iterator = catalogResource.listProperties(DCAT.dataset);
+        while (iterator.hasNext()) {
+            Statement statement = iterator.next();
+            datasetsInCatalog.add(statement.getObject().asResource().getURI());
+        }
+        return datasetsInCatalog;
     }
 
     DatasetLookup lookupDataset(Client client, String uri, Gson gson) {

--- a/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandler.java
+++ b/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandler.java
@@ -200,14 +200,16 @@ public class ElasticSearchResultHandler implements CrawlerResultHandler {
 
                 Set<String> missingUris = new HashSet<>(lastCatalogRecord.getValidDatasetUris());
                 missingUris.removeAll(thisCatalogRecord.getValidDatasetUris());
-                logger.info("There are {} datasets that were not harvested this time", missingUris.size());
+                if (missingUris.size() > 0) {
+                    logger.info("There are {} datasets that were not harvested this time", missingUris.size());
 
-                for (String uri : missingUris) {
-                    DatasetLookup lookup = lookupDataset(elasticsearch.getClient(), uri, gson);
-                    if (lookup != null && lookup.getDatasetId() != null) {
-                        elasticsearch.deleteDocument(DCAT_INDEX, DATASET_TYPE, lookup.getDatasetId());
-                        logger.info("deleted dataset {} with harvest uri {}", lookup.getDatasetId(), lookup.getHarvestUri());
-                        stats.setDeletes(stats.getDeletes() + 1);
+                    for (String uri : missingUris) {
+                        DatasetLookup lookup = lookupDataset(elasticsearch.getClient(), uri, gson);
+                        if (lookup != null && lookup.getDatasetId() != null) {
+                            elasticsearch.deleteDocument(DCAT_INDEX, DATASET_TYPE, lookup.getDatasetId());
+                            logger.info("deleted dataset {} with harvest uri {}", lookup.getDatasetId(), lookup.getHarvestUri());
+                            stats.setDeletes(stats.getDeletes() + 1);
+                        }
                     }
                 }
             }

--- a/applications/harvester-api/src/test/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandlerTest.java
+++ b/applications/harvester-api/src/test/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandlerTest.java
@@ -4,6 +4,9 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import no.dcat.shared.Dataset;
 import no.dcat.shared.Distribution;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.util.FileManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -76,24 +79,26 @@ public class ElasticSearchResultHandlerTest {
     public void setup() {
         resultHandler = new ElasticSearchResultHandler(null, 0, null, null, null, null);
         validationMessages = new Gson().fromJson(msgs, new TypeToken<List<String>>(){}.getType());
-
     }
 
     @Test
-    public void validationMessagesDataset1() {
+    public void validationMessageExtractionDataset1() {
         Dataset dataset = new Dataset();
-        dataset.setUri("http://data.norge.no/node/215");
+        dataset.setUri("http://data.norge.no/node/215/xxx");
+        Distribution distribution = new Distribution();
+        distribution.setUri("http://data.norge.no/node/960");
+        dataset.setDistribution(Arrays.asList(distribution));
+
         List<String> actual = resultHandler.getValidationMessages(validationMessages, dataset);
-
         logger.info(actual.toString());
-
-        assertThat(actual.size(), is(1));
+        assertThat("can extract validation message for distribution in dataset", actual.size(), is(1));
 
         dataset.setUri("http://data.norge.no/node/2121");
-
-        actual = resultHandler.getValidationMessages(validationMessages,dataset);
+        dataset.setDistribution(null);
+        actual = resultHandler.getValidationMessages(validationMessages, dataset);
         logger.info(actual.toString());
 
+        assertThat( "Can extract validation message for dataset", actual.size(), is(1));
     }
 
     @Test
@@ -109,5 +114,16 @@ public class ElasticSearchResultHandlerTest {
 
         logger.info(actual.toString());
 
+        assertThat("Should return 1 validation messages", actual.size(), is(1));
+
+    }
+
+    @Test
+    public void getDatasetUris() throws Throwable {
+        Model model = FileManager.get().loadModel("ramsund.ttl");
+
+        Set<String> actual = resultHandler.getDatasetsUris(model, "http://brreg.no/catalogs/910244132");
+
+        assertThat("Should return 4 dataset uris", actual.size(), is(4));
     }
 }

--- a/applications/search-api/src/main/java/no/dcat/portal/query/HarvestQueryService.java
+++ b/applications/search-api/src/main/java/no/dcat/portal/query/HarvestQueryService.java
@@ -69,7 +69,7 @@ public class HarvestQueryService extends ElasticsearchService {
                 .addAggregation(last7)
                 .addAggregation(last30)
                 .addAggregation(last365)
-                .setSize(20)
+                .setSize(0)
                 ;
 
         logger.trace("SEARCH: {}", searchQuery.toString());

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/AbstractBuilder.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/AbstractBuilder.java
@@ -541,17 +541,10 @@ public abstract class AbstractBuilder {
         publisher.setValid(extractAsBoolean(object, DCTerms.valid));
         publisher.setOrgPath(extractAsString(object, DCATNO.organizationPath));
 
-        Statement hasProperty = object.getProperty(EnhetsregisteretRDF.organisasjonsform);
-        if (hasProperty != null) {
-            publisher.setOrganisasjonsform(extractAsString(object, EnhetsregisteretRDF.organisasjonsform));
-        }
+        publisher.setOrganisasjonsform(extractAsString(object, EnhetsregisteretRDF.organisasjonsform));
+        publisher.setOverordnetEnhet(extractAsString(object, EnhetsregisteretRDF.overordnetEnhet));
 
-        hasProperty = object.getProperty(EnhetsregisteretRDF.overordnetEnhet);
-        if (hasProperty != null) {
-            publisher.setOverordnetEnhet(extractAsString(object, EnhetsregisteretRDF.overordnetEnhet));
-        }
-
-        hasProperty = object.getProperty(EnhetsregisteretRDF.naeringskode);
+        Statement hasProperty = object.getProperty(EnhetsregisteretRDF.naeringskode);
         if (hasProperty != null) {
             publisher.setNaeringskode(extractBRCode(hasProperty, "http://www.ssb.no/nace/sn2007/"));
         }

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/AbstractBuilder.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/AbstractBuilder.java
@@ -76,6 +76,21 @@ public abstract class AbstractBuilder {
         return null;
     }
 
+    public static String extractStringWithNoBaseUri(Resource resource, Property property) {
+        String valueToStrip = extractAsString(resource, property);
+        if ( valueToStrip != null) {
+            String uri = getStringWithNoBaseImportUri(resource.getModel(), valueToStrip);
+
+            if (uri.startsWith("http://")) {
+                return uri;
+            } else {
+                return "http://" + uri;
+            }
+        }
+
+        return null;
+    }
+
     public static String getStringWithNoBaseImportUri(Model model, String valueToStrip) {
         if (model != null && valueToStrip != null) {
             Resource importInformation = model.getResource(DCATCrawler.ImportResource.getURI());

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/DatasetBuilder.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/DatasetBuilder.java
@@ -95,7 +95,7 @@ public class DatasetBuilder extends AbstractBuilder {
 
                 Dataset datasetObject = create(datasetResource, catalog, locations, codes, dataThemes);
                 datasetObject.setDistribution(getDistributions(datasetResource, DCAT.distribution));
-                datasetObject.setSample(getDistributions(datasetResource, DCAT.sample));
+                datasetObject.setSample(getDistributions(datasetResource, ADMS.sample));
 
                 datasets.add(datasetObject);
             }
@@ -149,7 +149,7 @@ public class DatasetBuilder extends AbstractBuilder {
             ds.setModified(extractDate(resource, DCTerms.modified));
 
             ds.setLanguage(asList(getCode(codes.get(Types.linguisticsystem.getType()), extractAsString(resource, DCTerms.language))));
-            ds.setLandingPage(asList(extractStringWithNoBaseUri(resource, DCAT.landingPage)));
+            ds.setLandingPage(extractUriList(resource, DCAT.landingPage));
             ds.setTheme(extractTheme(resource, DCAT.theme, dataThemes));
 
             // distributions handled externally

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/DatasetBuilder.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/DatasetBuilder.java
@@ -149,7 +149,7 @@ public class DatasetBuilder extends AbstractBuilder {
             ds.setModified(extractDate(resource, DCTerms.modified));
 
             ds.setLanguage(asList(getCode(codes.get(Types.linguisticsystem.getType()), extractAsString(resource, DCTerms.language))));
-            ds.setLandingPage(asList(extractAsString(resource, DCAT.landingPage)));
+            ds.setLandingPage(asList(extractStringWithNoBaseUri(resource, DCAT.landingPage)));
             ds.setTheme(extractTheme(resource, DCAT.theme, dataThemes));
 
             // distributions handled externally

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/DcatBuilder.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/DcatBuilder.java
@@ -429,6 +429,7 @@ public class DcatBuilder {
                         addLiterals(disRes, DCTerms.title, distribution.getTitle());
                         addLiterals(disRes, DCTerms.description, distribution.getDescription());
                         addProperties(disRes, DCAT.accessURL, distribution.getAccessURL());
+                        addProperties(disRes, DCAT.downloadURL, distribution.getDownloadURL());
                         addSkosConcept(disRes, DCTerms.license, distribution.getLicense(), DCTerms.LicenseDocument);
 
                         addSkosConcepts(disRes, DCTerms.conformsTo, distribution.getConformsTo(), DCTerms.Standard);

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/DistributionBuilder.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/builders/DistributionBuilder.java
@@ -73,7 +73,8 @@ public class DistributionBuilder extends AbstractBuilder {
 
             dist.setTitle(extractLanguageLiteral(distResource, DCTerms.title));
             dist.setDescription(extractLanguageLiteral(distResource, DCTerms.description));
-            dist.setAccessURL(extractMultipleStrings(distResource, DCAT.accessUrl));
+            dist.setAccessURL(extractUriList(distResource, DCAT.accessUrl));
+            dist.setDownloadURL(extractUriList(distResource, DCAT.downloadUrl));
             List<SkosConcept> licences = extractSkosConcept(distResource, DCTerms.license);
             if (licences != null && licences.size()>0)
             dist.setLicense(licences.get(0));

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/client/LoadLocations.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/client/LoadLocations.java
@@ -61,7 +61,7 @@ public class LoadLocations {
 
         NodeIterator nodeIterator = model.listObjectsOfProperty(DCTerms.spatial);
         nodeIterator.forEachRemaining(node -> {
-            String uri = AbstractBuilder.getStringWithNoBaseImportUri(model, node.asResource().getURI());
+            String uri = AbstractBuilder.removeDefaultBaseUri(model, node.asResource().getURI());
 
             LocationUri locationUri = new LocationUri(uri);
 

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/smoke/TestCompleteCatalog.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/smoke/TestCompleteCatalog.java
@@ -133,7 +133,7 @@ public class TestCompleteCatalog {
                 "NOR",
                 map("nb", "Norsk"))));
 
-        dataset.setLandingPage(Collections.singletonList("http://testetaten.no/landingsside/nr1"));
+        dataset.setLandingPage(Arrays.asList("http://testetaten.no/landingsside/nr1", "www.this.can.happen/also"));
         DataTheme theme = new DataTheme();
         theme.setUri("http://publications.europa.eu/resource/authority/data-theme/GOVE");
         theme.setCode("GOVE");
@@ -164,7 +164,7 @@ public class TestCompleteCatalog {
 
         sample.setDescription(map("nb", "Dette er beskrivelsen av eksempeldataene. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor."));
         sample.setFormat(Arrays.asList("application/rdf+xml"));
-        sample.setAccessURL(Arrays.asList("http://www.detteerenlenke.no/til-nedlasting"));
+        sample.setAccessURL(Arrays.asList("http://www.detteerenlenke.no/til-nedlasting", "www.dette.kan.også/hende"));
 
         dataset.setSample(Arrays.asList(sample));
 

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/vocabulary/DCAT.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/vocabulary/DCAT.java
@@ -24,13 +24,15 @@ public class DCAT {
 	public static final Property Distribution = model.createProperty(NS, "Distribution");
 	
 	public static final Property distribution = model.createProperty(NS, "distribution");
-	public static final Property sample = model.createProperty(NS, "sample");
+
 	public static final Property Catalog = model.createProperty(NS, "Catalog");
 
 	public static final Property themeTaxonomy = model.createProperty(NS, "themeTaxonomy");
 
 	public static final Property accessUrl = model.createProperty(NS, "accessURL");
-	
+
+	public static final Property downloadUrl = model.createProperty(NS, "downloadURL");
+
 	public static final Property landingPage = model.createProperty(NS, "landingPage");
 
 	public static final Property keyword = model.createProperty(NS, "keyword");

--- a/libraries/datastore/src/test/java/no/dcat/datastore/domain/dcat/DatasetTest.java
+++ b/libraries/datastore/src/test/java/no/dcat/datastore/domain/dcat/DatasetTest.java
@@ -64,6 +64,7 @@ public class DatasetTest {
         return codes;
     }
 
+
     @Test
     public void publisherExists() {
         no.dcat.shared.Publisher actual = data.getPublisher();


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
https://jira.brreg.no/browse/FDK-953

Har lagt til sjekk av dataset.landingPage og distribution.accessUrl/downloadUrl. Hvis protokoll ikke er oppgitt får de nå http:/ før verdien.

Har gjort noen små generelle endringer.
- Publisher: organisasjoner med orgform SF blir nå lagt under STAT
- fikset aggregeringssøket på harvest til å ikke returnere søket men kun aggregeringen
- Fikset problemer med for mange ugyldige datasett i harvest catalog record. 
- Lagt til bedre logikk for å håndtere publishere uten uri.
- noe navngiving

> check applicable boxes

- [x] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
