### PR TITLE
run react coverage report only during cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,10 @@ jobs:
 
     - stage: Tests # Run regular React unit tests
       script: cd applications/search && npm install npm -g npm@'>=5.4.2' && npm install && npm test
+      if: type = cron #run only during nightly cron job
       after_success: npm run coverage
       env:
-        - comment=Run regular React unit tests
+        - comment=Run regular React unit tests + generate test coverage report
 
     #- stage: Tests # Run Angular e2e tests
     #  if: type = cron #run only during nightly cron job - time-consuming operation


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories

run react coverage report only during cron job