### PR TITLE
add and remove helptexts

### DIFF
--- a/applications/registration/src/app/catalog/catalog.component.html
+++ b/applications/registration/src/app/catalog/catalog.component.html
@@ -3,9 +3,6 @@
     <div >
       <div class="">
         <div class="form-group">
-          <helptext
-            name="Catalog_title">
-          </helptext>
           <h1>
             <input id="tittel-datakatalog" (ngModelChange)="valuechange()" type="text" class="fdk-register-h1" placeholder="Tittel" [(ngModel)]="catalog.title[language]"/>
           </h1>
@@ -20,7 +17,7 @@
       <div class="fdk-container fdk-container-expanded" style="margin-top:20px" [hidden]="!descriptionExpanded">
         <label class="fdk-input-label">Beskrivelse <span class="fdk-obligatorisk">Obligatorisk</span></label>
         <helptext
-          name="Catalog_description">
+          name="Catalog_title">
         </helptext>
         <textarea class="" (blur)="descriptionExpanded = !descriptionExpanded" (ngModelChange)="valuechange()" rows="5" id="beskrivelse-datakatalog" placeholder="Beskrivelse" [(ngModel)]='catalog.description[language]'></textarea>
       </div>

--- a/applications/registration/src/app/dataset/contact/contact.component.html
+++ b/applications/registration/src/app/dataset/contact/contact.component.html
@@ -1,9 +1,6 @@
 <div class="" *ngIf="contactForm">
   <div [formGroup]="contactForm" class="form-group">
     <div class="fdk-input-container">
-      <helptext
-        name="Dataset_contactPoint">
-      </helptext>
       <p class="fdk-input-label">Kontaktpunkt</p>
       <helptext
         name="ContactPoint_organizational-unit">

--- a/applications/registration/src/app/dataset/distribution/distribution.component.html
+++ b/applications/registration/src/app/dataset/distribution/distribution.component.html
@@ -2,9 +2,6 @@
     <div class="form-group" style="margin-bottom: 7px;">
         <div class="form sub-form" *ngIf="showForm">
             <div id="distributionTypeSelector-for-{{componentTitle}}-{{distributionIndex}}">
-              <helptext
-                name="Distribution_type">
-              </helptext>
                 <div class="fdk-radio" *ngFor="let type of typeModel">
                     <input
                         type="radio"


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
Fra Jira:
Hjelpetekst øverst på katalogsiden må flyttes til under beskrivelse av Datakatalogen. Erstatt teksten som ligger der, da den er feil. Rettet
Fjern hjelpetekst over Kontaktpunkt Rettet
Fjern hjelpetekst over den "usynelige" label Distribusjonstype Rettet
Innhold (overordnet) -> viser hjelpetekt til oppdateringsfrekvens? OIS: Viser for conformsTo (Dataset_conformsTo).
