### PR TITLE
Feature/fdk 1048 patch

### DIFF
--- a/applications/registration-api/src/main/java/no/dcat/controller/DatasetController.java
+++ b/applications/registration-api/src/main/java/no/dcat/controller/DatasetController.java
@@ -176,8 +176,6 @@ public class DatasetController {
 
         Gson gson = new Gson();
 
-        //TODO: gjøre en isJson sjekk på updatene
-
         //get already saved dataset
         Dataset oldDataset = datasetRepository.findOne(datasetId);
         logger.info("found old dataset: {}" + oldDataset.getTitle().get("nb"));

--- a/applications/registration-api/src/main/java/no/dcat/controller/DatasetController.java
+++ b/applications/registration-api/src/main/java/no/dcat/controller/DatasetController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.Calendar;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
@@ -35,6 +36,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 import static org.springframework.web.bind.annotation.RequestMethod.PUT;
+import static org.springframework.web.bind.annotation.RequestMethod.PATCH;
 
 @Controller
 @RequestMapping("/catalogs/{catalogId}/datasets")
@@ -128,6 +130,7 @@ public class DatasetController {
         return new ResponseEntity<ErrorResponse>(error, HttpStatus.NOT_FOUND);
     }
 
+
     /**
      * Modify dataset in catalog.
      * @param dataset
@@ -137,7 +140,7 @@ public class DatasetController {
     @CrossOrigin
     @RequestMapping(value = "/{id}", method = PUT, consumes = APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public HttpEntity<Dataset> saveDataset(@PathVariable("catalogId") String catalogId, @PathVariable("id") String datasetId, @RequestBody Dataset dataset) {
-        logger.info("requestbody dataset: " + dataset.toString());
+        logger.info("PUT requestbody dataset: " + dataset.toString());
         dataset.setId(datasetId);
         dataset.setCatalogId(catalogId);
 
@@ -154,15 +157,53 @@ public class DatasetController {
         return new ResponseEntity<>(savedDataset, HttpStatus.OK);
     }
 
+
     /**
-     * Return list of all datasets in catalog.
-     * Without parameters, the first 20 datasets are returned
-     * The returned data contains paging hyperlinks.
-     * <p>
-     * @param catalogId the id of the catalog
-     * @param pageable number of datasets returned
-     * @return List of data sets, with hyperlinks to other pages in search result
+     * Modify dataset in catalog.
+     * @param updates Objects in datatset to be updated
+     * @return HTTP 200 OK if dataset could be could be updated.
      */
+    @PreAuthorize("hasPermission(#catalogId, 'write')")
+    @CrossOrigin
+    @RequestMapping(value = "/{id}", method = PATCH, consumes = APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public HttpEntity<Dataset> updateDataset(@PathVariable("catalogId") String catalogId,
+                                             @PathVariable("id") String datasetId,
+                                             @RequestBody Map<String, Object> updates) {
+        logger.info("PATCH requestbody update dataset: " + updates.toString());
+
+        //get already saved dataset
+        Dataset oldDataset = datasetRepository.findOne(datasetId);
+
+        //TODO: Blir dette riktig håndtering av et ikke-eksisterende datasett ved patch?
+        if (oldDataset == null || !Objects.equals(catalogId, oldDataset.getCatalogId())) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        for(Map.Entry<String, Object> entry : updates.entrySet()) {
+            logger.debug("update key: {} value: ", entry.getKey(), entry.getValue() );
+        }
+
+
+
+        //Add metaifnormation about editing
+        //dataset.set_lastModified(Calendar.getInstance().getTime());
+
+        //Dataset savedDataset = datasetRepository.save(dataset);
+        //return new ResponseEntity<>(savedDataset, HttpStatus.OK);
+
+        return null;
+    }
+
+
+        /**
+         * Return list of all datasets in catalog.
+         * Without parameters, the first 20 datasets are returned
+         * The returned data contains paging hyperlinks.
+         * <p>
+         * @param catalogId the id of the catalog
+         * @param pageable number of datasets returned
+         * @return List of data sets, with hyperlinks to other pages in search result
+         */
     @PreAuthorize("hasPermission(#catalogId, 'write')")
     @CrossOrigin
     @RequestMapping(value = "", method = GET, produces = APPLICATION_JSON_UTF8_VALUE)

--- a/applications/registration-api/src/main/java/no/dcat/controller/DatasetController.java
+++ b/applications/registration-api/src/main/java/no/dcat/controller/DatasetController.java
@@ -180,7 +180,6 @@ public class DatasetController {
         Dataset oldDataset = datasetRepository.findOne(datasetId);
         logger.info("found old dataset: {}" + oldDataset.getTitle().get("nb"));
 
-        //TODO: Blir dette riktig håndtering av et ikke-eksisterende datasett ved patch?
         if (oldDataset == null || !Objects.equals(catalogId, oldDataset.getCatalogId())) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }

--- a/applications/registration-api/src/test/java/no/dcat/controller/DatasetControllerIT.java
+++ b/applications/registration-api/src/test/java/no/dcat/controller/DatasetControllerIT.java
@@ -193,6 +193,7 @@ public class DatasetControllerIT {
         String catalogId = "910244132";
         String datasetId = createCatalogAndSimpleDataset(catalogId);
 
+        Map<String,Object> updates = new HashMap<>();
 
         Map<String,Object> relevanceAnnotaton = new HashMap<>();
         relevanceAnnotaton.put("inDimension", "iso:Relevance");

--- a/applications/registration-api/src/test/java/no/dcat/controller/DatasetControllerIT.java
+++ b/applications/registration-api/src/test/java/no/dcat/controller/DatasetControllerIT.java
@@ -146,6 +146,40 @@ public class DatasetControllerIT {
     }
 
 
+    @Test
+    @WithUserDetails("03096000854")
+    public void patchMultipleAttributesInDatasetShouldWork() throws Exception {
+
+        //setup test data
+        String catalogId = "910244132";
+        String datasetId = createCatalogAndSimpleDataset(catalogId);
+
+        //Update both type and title
+        Map<String,Object> updates = new HashMap<>();
+        updates.put("type", "Kodeverk");
+        Map<String,String> languageTitle = new HashMap<>();
+        languageTitle.put("nb", "Endret tittel");
+        updates.put("title", languageTitle);
+
+        //change the dataset with patch operation
+        mockMvc
+                .perform(
+                        MockMvcRequestBuilders
+                                .patch("/catalogs/" + catalogId + "/datasets/" + datasetId)
+                                .content(asJsonString(updates))
+                                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        //check that the dataset was actually changed
+        mockMvc
+                .perform(MockMvcRequestBuilders.get("/catalogs/" + catalogId + "/datasets/" + datasetId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.type").value("Kodeverk"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.title.nb").value("Endret tittel"))
+                .andExpect(status().isOk());
+    }
+
+
 
     @Test
     public void unauthorizedPostOfDatasetShouldRedirectToLoginPage() throws Exception {

--- a/applications/registration-api/src/test/java/no/dcat/controller/DatasetControllerIT.java
+++ b/applications/registration-api/src/test/java/no/dcat/controller/DatasetControllerIT.java
@@ -120,43 +120,11 @@ public class DatasetControllerIT {
     @Test
     @WithUserDetails("03096000854")
     public void patchDatasetFollowedByGetRequestShouldWork() throws Exception {
-        Catalog catalog = new Catalog();
+
+        //setup test data
         String catalogId = "910244132";
-        catalog.setId(catalogId);
-        mockMvc
-                .perform(
-                        MockMvcRequestBuilders
-                                .post("/catalogs")
-                                .content(asJsonString(catalog))
-                                .contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andExpect(status().isOk());
+        String datasetId = createCatalogAndSimpleDataset(catalogId);
 
-
-        //create dataset to be changed later
-        Dataset dataset = new Dataset();
-
-        Map<String, String> languageTitle = new HashMap<>();
-        languageTitle.put("nb", "Test-tittel");
-        dataset.setTitle(languageTitle);
-
-        Map<String, String> languangeDescription = new HashMap<>();
-        languangeDescription.put("nb", "test");
-        dataset.setDescription(languangeDescription);
-        dataset.setType("Testdata");
-
-        String datasetResponseJson = mockMvc
-                .perform(
-                        MockMvcRequestBuilders
-                                .post("/catalogs/" + catalogId + "/datasets/")
-                                .content(asJsonString(dataset))
-                                .contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andDo(print())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.type").value("Testdata"))
-                .andExpect(status().isOk())
-                .andReturn().getResponse().getContentAsString();
-
-
-        String datasetId = new Gson().fromJson(datasetResponseJson, Dataset.class).getId();
         Map<String,String> updates = new HashMap<>();
         updates.put("type", "Kodeverk");
 
@@ -175,8 +143,6 @@ public class DatasetControllerIT {
                 .perform(MockMvcRequestBuilders.get("/catalogs/" + catalogId + "/datasets/" + datasetId))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.type").value("Kodeverk"))
                 .andExpect(status().isOk());
-
-
     }
 
 
@@ -337,6 +303,50 @@ public class DatasetControllerIT {
 
         logger.info(expected.getReferences().toString());
 
+    }
+
+    /**
+     * Helper function to create a catalog and simple dataset
+     * to be used in tests
+     * @param catalogId id of catalog to be created
+     * @return id of created dataset
+     */
+    public String createCatalogAndSimpleDataset(String catalogId) throws Exception {
+        Catalog catalog = new Catalog();
+        catalog.setId(catalogId);
+        mockMvc
+                .perform(
+                        MockMvcRequestBuilders
+                                .post("/catalogs")
+                                .content(asJsonString(catalog))
+                                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(status().isOk());
+
+
+        //create dataset to be changed later
+        Dataset dataset = new Dataset();
+
+        Map<String, String> languageTitle = new HashMap<>();
+        languageTitle.put("nb", "Test-tittel");
+        dataset.setTitle(languageTitle);
+
+        Map<String, String> languangeDescription = new HashMap<>();
+        languangeDescription.put("nb", "test");
+        dataset.setDescription(languangeDescription);
+        dataset.setType("Testdata");
+
+        String datasetResponseJson = mockMvc
+                .perform(
+                        MockMvcRequestBuilders
+                                .post("/catalogs/" + catalogId + "/datasets/")
+                                .content(asJsonString(dataset))
+                                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andDo(print())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.type").value("Testdata"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        return new Gson().fromJson(datasetResponseJson, Dataset.class).getId();
     }
 
 }


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/FDK-1048

Implementasjon av patch for dataset i registration-api.
Sikkert lurt å dobbeltsjekke koden i denne.

Oppdaget også at det er en RFC for patch, som sier at man skal spesifisere operasjon i tillegg til en map av felter og verdier:

https://tools.ietf.org/html/rfc6902

Denne er ikke fulgt, det er nok en større jobb å implementere den, da det kan være ulike typer operasjoner for ulike felt. Men det kan være noe vi legger i backloggen.

> check applicable boxes

- [ x] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
