### PR TITLE
handle null validation results

### DIFF
--- a/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandler.java
+++ b/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandler.java
@@ -213,9 +213,13 @@ public class ElasticSearchResultHandler implements CrawlerResultHandler {
             logger.debug("/harvest/catalog/_indexRequest:\n{}", gson.toJson(catalogRecord));
 
             //add validation results to log to send to datasource owner
-            harvestLog.info("Validation results for catalog " + catalog.getId() + " :");
-            for(String validationResult : validationResults) {
-                harvestLog.info(validationResult);
+            harvestLog.info("Validation results for catalog {}:", catalog.getId());
+            if(validationResults != null) {
+                for (String validationResult : validationResults) {
+                    harvestLog.info(validationResult);
+                }
+            } else {
+                harvestLog.info("No validation results found for catalog {}", catalog.getId());
             }
         }
 


### PR DESCRIPTION
Fikser feil som oppstod i integrasjonstest som sendte null-parameter for valideringsresultater til ElasticsearchResultHandler.

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
