### PR TITLE
added environment variables for harvester user name and password

### DIFF
--- a/applications/registration-api/src/main/resources/application.yml
+++ b/applications/registration-api/src/main/resources/application.yml
@@ -9,8 +9,8 @@ application:
   clientSSLCertificateKeystorePassword: ${registrationApi_clientSSLCertificateKeystorePassword:password}
   httpUsername: ${themesHttpUsername:user}
   httpPassword: ${themesHttpPassword:password}
-  harvesterUsername: ${registrationApi_harvesterUsername}
-  harvesterPassword: ${registrationApi_harvesterPassword}
+  harvesterUsername: ${registrationApi_harvesterUsername:test_admin}
+  harvesterPassword: ${registrationApi_harvesterPassword:password}
   harvesterUrl: http://harvester:8080
 
 spring:

--- a/runCreateServiceInOpenshift.sh
+++ b/runCreateServiceInOpenshift.sh
@@ -101,6 +101,7 @@ deploymode=$5
 environmentTag=$2_latest
 openshiftProject=fellesdatakatalog-$environment
 
+
 #configuration that differs between nonprod and prod clusters
 if [ $environment = ppe ] || [ $environment = prd ]
 then
@@ -115,6 +116,9 @@ then
     sslKeystoreLocation=conf/idporten/ssldevelop.p12
     clientCertificateKeystoreLocation="conf/altinn/Buypass ID-REGISTERENHETEN-I-BRONNOYSUND-serienummer13439118435479952733750626-2017-05-10.p12"
     registrationApiIdportenMetadatafile="conf/idporten/idporten.difi.no-v3-prod-meta_sign.xml"
+
+    registrationApiHarvesterUserName=changeme
+    registrationApiHarvesterPassword=changeme
 else
     #run on non-prod cluster if environment is ut1, st1, st2, tt1
     cluster=ose-npc
@@ -134,6 +138,9 @@ else
     sslKeystoreLocation=conf/idporten/ssldevelop.p12
     clientCertificateKeystoreLocation="conf/altinn/Buypass ID-REGISTERENHETEN I BROENNOEYSUND-serienummer1544700822686643554309384-2017-05-31.p12"
     registrationApiIdportenMetadatafile="conf/idporten/idporten-ver2.difi.no-v3_signed_meta.xml"
+
+    registrationApiHarvesterUserName=changeme
+    registrationApiHarvesterPassword=changeme
 fi
 
 host=$environment.$cluster.brreg.no
@@ -310,7 +317,9 @@ then
             registrationApi_ipStorePassword=changeit \
             registrationApi_sslKeyPassword=changeit \
             registrationApi_sslKeystoreLocation=$sslKeystoreLocation \
-            registrationApi_idportenMetadataFile=$registrationApiIdportenMetadatafile
+            registrationApi_idportenMetadataFile=$registrationApiIdportenMetadatafile \
+            registrationApi_harvesterUsername=$registrationApiHarvesterUserName \
+            registrationApi_harvesterPassword=$registrationApiHarvesterPassword
 
         echo "Registration-api: Keystore password environment variables must be set manually"
         echo "Registration-api: Remember to mount /conf volume"


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

Registration-api trenger et par nye miljøvariabler for å vite hvordan den skal kommunisere med harvesteren.
Har modifisert scriptet som oppretter tjenestene i Openshift, slik det oppretter miljøvariablene.

> check applicable boxes

- [ ] I have made tests to match the user stories
- [x ] This code does not require tests that match user stories
