### PR TITLE
harvester data source now uses internal url to registration-api due t…

### DIFF
--- a/applications/registration-api/src/main/java/no/dcat/controller/CatalogController.java
+++ b/applications/registration-api/src/main/java/no/dcat/controller/CatalogController.java
@@ -301,6 +301,10 @@ public class CatalogController {
      * @return String containing base uri
      */
     public String getRegistrationBaseUrl() {
+
+        /*
+        Temporary: use internal url instead of external one due to routing issues
+
         StringBuilder host = new StringBuilder();
         String protocol = "https://";
         host.append(protocol);
@@ -309,6 +313,8 @@ public class CatalogController {
             host.append(":").append(serverPort);
         }
         return host.toString();
+        */
+        return "http://registration-api:8080";
     }
 
 }


### PR DESCRIPTION
datakildene som opprettes i harvester, får nå intern lenke til registrerings-api, i stedet for den eksterne.
Dette pga at den eksterne rutingen ikke fungerer i testmiljøene. I prod-miljøet fungerer både interne og eksterne ruter.


<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
