### PR TITLE
FDK-1091 removed separate surefire plugin configuration for module da…

### DIFF
--- a/libraries/datastore/pom.xml
+++ b/libraries/datastore/pom.xml
@@ -70,15 +70,4 @@
 
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<argLine>-noverify</argLine>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>


### PR DESCRIPTION
…tastore

<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/FDK-1091

Fikset feil som gjorde at testdekningsrapporten for enhetstestene i modulen datastore ikke ble med.
Dette skyldtes at datastore hadde sitt eget oppsett av surefire plugin, som overskrev konfigurasjonen i parent pom.

Modul shared har ingen tester, derfor rapporteres ikke testdektning derfra.

> check applicable boxe

- [ ] I have made tests to match the user stories
- [ x] This code does not require tests that match user stories
