### PR TITLE
Changed from image on java applications from 8-jre to 8-jre-alpine, s…

### DIFF
--- a/applications/dev-management/src/main/docker/Dockerfile
+++ b/applications/dev-management/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/applications/fuseki/src/main/docker/Dockerfile
+++ b/applications/fuseki/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8-jre8
+FROM tomcat:8-jre8-alpine
 
 ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/applications/harvester-api/src/main/docker/Dockerfile
+++ b/applications/harvester-api/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/applications/harvester/src/main/docker/Dockerfile
+++ b/applications/harvester/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/applications/reference-data/src/main/docker/Dockerfile
+++ b/applications/reference-data/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/applications/registration-api/src/main/docker/Dockerfile
+++ b/applications/registration-api/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/applications/registration-auth/src/main/docker/Dockerfile
+++ b/applications/registration-auth/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/applications/registration-validator/src/main/docker/Dockerfile
+++ b/applications/registration-validator/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/applications/search-api/src/main/docker/Dockerfile
+++ b/applications/search-api/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/runDocker.sh
+++ b/runDocker.sh
@@ -6,7 +6,7 @@ set -e
  docker-compose stop $1 || true
  docker-compose up -d $1
 
-docker-compose restart nginx
+docker-compose restart nginx-registration
 
 if [ "$2" == "logs" ]; then
    docker-compose logs -f $1


### PR DESCRIPTION
Har byttet java image fra 8-jre til 8-jre-alpine. Det fører til ca 60% mindre docker images. Dvs. vi er nå nede på rundt 250MB for et java image.
Fikset også en forglemmelse i runDocker.sh