### PR TITLE
Hotfix/harvest metadata query

### DIFF
--- a/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandler.java
+++ b/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandler.java
@@ -647,7 +647,7 @@ public class ElasticSearchResultHandler implements CrawlerResultHandler {
             DatasetHarvestRecord lastHarvestRecordWithContent;
 
             // compensate if we do not have first harvest date (handles old way) harvest records.
-            if (lookupEntry.getHarvest().getFirstHarvested() == null) {
+            if (true) { // TODO replace lookupEntry.getHarvest().getFirstHarvested() == null) {
                 // this should be removed - TODO
                 logger.info("Compensating actions for dataset: {}", dataset.getUri());
                 lookupEntry.getHarvest().setFirstHarvested(getFirstHarvestedDate(dataset, elasticsearch, gson));

--- a/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandler.java
+++ b/applications/harvester-api/src/main/java/no/dcat/harvester/crawler/handlers/ElasticSearchResultHandler.java
@@ -373,7 +373,7 @@ public class ElasticSearchResultHandler implements CrawlerResultHandler {
         ExistsQueryBuilder hasDatasetValue = QueryBuilders.existsQuery("dataset");
 
         BoolQueryBuilder datasetWithValueQuery = QueryBuilders.boolQuery();
-        datasetWithValueQuery.should(hasDatasetId).should(hasDatasetValue);
+        datasetWithValueQuery.must(hasDatasetId).must(hasDatasetValue);
 
         logger.debug("query: {}", datasetWithValueQuery.toString());
 
@@ -391,6 +391,8 @@ public class ElasticSearchResultHandler implements CrawlerResultHandler {
                 logger.debug("Found {} harvested at {}", lastHarvestRecord.getDatasetId(), dateFormat.format(lastHarvestRecord.getDate()));
 
                 return lastHarvestRecord;
+            } else {
+                logger.info("Dataset {} has no harvest metadata and are never harvested before", dataset.getUri());
             }
 
         }


### PR DESCRIPTION
Har brukt feil spørring mot Elastic, derfor blir alle dataset tolket som endring. Jeg har lagt til en kompenserende ting som kjører gjennom alle tidligere harvestede datatasett og sletter duplikater. Dette fører til at harvesteren vil gå litt tregere. Dette bør fjernes når vi går mot produksjon. Men eneste måte å få testet historikken på i testmiljøene.