### PR TITLE
(registration-api, concept-cat) API-563 Elasticsearch index generatio…

### DIFF
--- a/applications/concept-cat/src/main/java/no/ccat/model/ConceptDenormalized.java
+++ b/applications/concept-cat/src/main/java/no/ccat/model/ConceptDenormalized.java
@@ -15,8 +15,6 @@ import org.springframework.hateoas.core.Relation;
 @EqualsAndHashCode(callSuper = true)
 @Relation(value = "concept", collectionRelation = "concepts")
 @Document(indexName = "ccat", type = "concept")
-@Setting(settingPath = "ccat.settings.json")
-@Mapping(mappingPath = "conceptdenormalized.mapping.json")
 public class ConceptDenormalized extends Concept {
 
     @ApiModelProperty("The publisher of the concept [dct:publisher]")

--- a/applications/registration-api/src/main/java/no/dcat/service/ElasticsearchService.java
+++ b/applications/registration-api/src/main/java/no/dcat/service/ElasticsearchService.java
@@ -31,6 +31,12 @@ public class ElasticsearchService {
             elasticClient.registerSetting("reg-api-catalog", mapper.readTree(new ClassPathResource("reg-api-catalog.settings.json").getInputStream()).toString());
             elasticClient.registerMapping("reg-api-catalog", "apicatalog", mapper.readTree(new ClassPathResource("apicatalog.mapping.json").getInputStream()).get("apicatalog").toString());
             elasticClient.initializeAliasAndIndexMapping("reg-api-catalog");
+
+            elasticClient.registerSetting("register", mapper.readTree(new ClassPathResource("register.settings.json").getInputStream()).toString());
+            elasticClient.registerMapping("register", "dataset", mapper.readTree(new ClassPathResource("register.dataset.mapping.json").getInputStream()).get("dataset").toString());
+            elasticClient.registerMapping("register", "catalog", mapper.readTree(new ClassPathResource("register.catalog.mapping.json").getInputStream()).get("catalog").toString());
+            elasticClient.initializeAliasAndIndexMapping("register");
+
         } catch (IOException e) {
             throw new RuntimeException("Unable to intialize elasticsearch index", e);
         }

--- a/applications/registration-api/src/main/resources/register.catalog.mapping.json
+++ b/applications/registration-api/src/main/resources/register.catalog.mapping.json
@@ -1,0 +1,9 @@
+{
+  "catalog": {
+    "properties": {
+      "id": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/applications/registration-api/src/main/resources/register.dataset.mapping.json
+++ b/applications/registration-api/src/main/resources/register.dataset.mapping.json
@@ -1,0 +1,27 @@
+{
+  "dataset": {
+    "properties": {
+      "registrationStatus": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "ignore_above": 256,
+            "type": "keyword"
+          }
+        }
+      },
+      "id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "ignore_above": 256,
+            "type": "keyword"
+          }
+        }
+      },
+      "_lastModified": {
+        "type": "date"
+      }
+    }
+  }
+}

--- a/applications/registration-api/src/main/resources/register.settings.json
+++ b/applications/registration-api/src/main/resources/register.settings.json
@@ -1,0 +1,16 @@
+{
+  "analysis": {
+    "analyzer": {
+      "path-analyzer": {
+        "type": "custom",
+        "tokenizer": "path-tokenizer"
+      }
+    },
+    "tokenizer": {
+      "path-tokenizer": {
+        "type": "path_hierarchy",
+        "delimiter": "/"
+      }
+    }
+  }
+}


### PR DESCRIPTION
…n and update is now consistent for all indexes. Registration api now uses index definition files and code for automatic update of indexes like the other components. Also fixed error in index generation for concept-cat when running in docker.

<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/API-563

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
