### PR TITLE
fix (informationmodel-cat) Show total number of informationmodels in tab

### DIFF
--- a/applications/search/src/redux/modules/informationModels.js
+++ b/applications/search/src/redux/modules/informationModels.js
@@ -55,7 +55,8 @@ export function informationModelsReducer(state = initialState, action) {
           '_embedded.informationmodels'
         ),
         informationModelAggregations: _.get(action.payload, 'aggregations'),
-        informationModelTotal: _.get(action.payload, 'total'),
+        informationModelTotal: _.get(action.payload, ['page', 'totalElements']),
+
         meta: {
           isFetching: false,
           lastFetch: Date.now(),


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
