### PR TITLE
(search) API-838 make environment variable with disqus shortname avai…

### DIFF
--- a/applications/search/Dockerfile
+++ b/applications/search/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache git
 RUN npm init -y
 RUN npm config set unsafe-perm true
 RUN npm install ejs express method-override body-parser compression --loglevel error
-RUN npm install pm2 -g --loglevel error
+RUN npm install pm2 webpack webpack-cli cross-var -g --loglevel error
 
 # Create app directory
 RUN mkdir -p /usr/src/app && chmod 777 /usr/src/app
@@ -15,6 +15,8 @@ WORKDIR /usr/src/app
 
 COPY package.json /usr/src/app/package.json
 COPY package-lock.json /usr/src/app/package-lock.json
+COPY build.sh /usr/src/app/build.sh
+RUN chmod u+x /usr/src/app/build.sh
 
 # Install app dependencies
 RUN npm install --only=production --loglevel=warn
@@ -27,8 +29,8 @@ COPY webpack.* /usr/src/app/
 # most volatile directory latest, in order to reuse layers.
 COPY src /usr/src/app/src
 
-RUN npm run build
-
 EXPOSE 3000
 
-CMD [ "pm2-docker", "start.js" ]
+# build application after docker container have started and env variables are set
+ENTRYPOINT /usr/src/app/build.sh
+CMD ["pm2-docker", "start.js"]

--- a/applications/search/build.sh
+++ b/applications/search/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+echo Running webpack. Disqus shortname:
+echo $DISQUS_SHORTNAME
+webpack --config webpack.prod.config.js -p
+pm2-docker start.js

--- a/applications/search/server/server.js
+++ b/applications/search/server/server.js
@@ -16,6 +16,8 @@ module.exports = {
       disqusShortname: process.env.DISQUS_SHORTNAME
     };
 
+    console.log("disqus shortname: " + env.disqusShortname);
+
     const app = express();
     app.use(compression());
     app.set('view engine', 'ejs');

--- a/applications/search/server/server.js
+++ b/applications/search/server/server.js
@@ -16,8 +16,6 @@ module.exports = {
       disqusShortname: process.env.DISQUS_SHORTNAME
     };
 
-    console.log("disqus shortname: " + env.disqusShortname);
-
     const app = express();
     app.use(compression());
     app.set('view engine', 'ejs');

--- a/applications/search/src/config.js
+++ b/applications/search/src/config.js
@@ -1,4 +1,5 @@
 export const config = {
   reduxLog: process.env.REDUX_LOG === '1',
   disqusShortname: process.env.DISQUS_SHORTNAME
-};
+}
+console.log(process.env);

--- a/applications/search/src/config.js
+++ b/applications/search/src/config.js
@@ -2,4 +2,3 @@ export const config = {
   reduxLog: process.env.REDUX_LOG === '1',
   disqusShortname: process.env.DISQUS_SHORTNAME
 }
-console.log(process.env);

--- a/applications/search/webpack.prod.config.js
+++ b/applications/search/webpack.prod.config.js
@@ -76,12 +76,10 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production'),
-        REDUX_LOG: JSON.stringify(process.env.REDUX_LOG),
-        DISQUS_SHORTNAME: JSON.stringify(process.env.DISQUS_SHORTNAME)
-      }
+      'process.env.NODE_ENV': JSON.stringify('production'),
+      'process.env.REDUX_LOG' : JSON.stringify(process.env.REDUX_LOG)
     }),
+    new webpack.EnvironmentPlugin(['DISQUS_SHORTNAME']),
     new webpack.LoaderOptionsPlugin({
       minimize: true,
       debug: false


### PR DESCRIPTION
…lable in client also when building application with webpack in production mode. The application must be built after the Docker container is up and running, as environment variables are not available earlier

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
