### PR TITLE
Hotfix/bjg/harvester syntax error

### DIFF
--- a/applications/harvester-api/src/test/java/no/dcat/harvester/crawler/CrawlerValidationIT.java
+++ b/applications/harvester-api/src/test/java/no/dcat/harvester/crawler/CrawlerValidationIT.java
@@ -53,7 +53,7 @@ public class CrawlerValidationIT {
         CrawlerJob crawlerJob = new CrawlerJob(dcatSource,null, subjectCrawler);
         Model model = crawlerJob.loadModelAndValidate(r.getURL());
 
-       // model.write(System.out, "TURTLE");
+        // model.write(System.out, "TURTLE");
 
         DcatReader reader = setupReader(model);
         List<Dataset> datasets = reader.getDatasets();
@@ -72,6 +72,29 @@ public class CrawlerValidationIT {
         boolean notFound = datasets.stream().noneMatch(dataset -> dataset.getUri().startsWith("https://data.norge.no/node/1939"));
         assertThat("the dataset is not found after removing non-valid dataset", notFound, is(true));
         assertThat("the number of datasets after removing non-valid dataset", datasets.size(), is(549));
+
+    }
+
+
+    @Test
+    public void readGeonorgeDataWithWrongSpatialProperty() throws Throwable {
+
+        Resource r = new ClassPathResource("geonorge-spatial-resource.xml");
+        DcatSource dcatSource = new DcatSource();
+        dcatSource.setUrl("http://testurl");
+        CrawlerJob crawlerJob = new CrawlerJob(dcatSource,null, subjectCrawler);
+        Model model = crawlerJob.loadModelAndValidate(r.getURL());
+
+        DcatReader reader = setupReader(model);
+        List<Dataset> datasets = reader.getDatasets();
+
+        Dataset found = datasets.stream().filter(dataset ->
+            dataset.getUri().startsWith("https://kartkatalog.geonorge.no/Metadata/uuid/041f1e6e-bdbc-4091-b48f-8a5990f3cc5b"))
+            .findFirst().get();
+
+        assertThat("the dataset is found in modeldata", found, is(notNullValue()));
+        assertThat("the number of datasets in model", datasets.size() , is(1));
+
 
     }
 

--- a/applications/harvester-api/src/test/java/no/dcat/harvester/validation/DcatValidationTest.java
+++ b/applications/harvester-api/src/test/java/no/dcat/harvester/validation/DcatValidationTest.java
@@ -80,6 +80,7 @@ public class DcatValidationTest {
 
     }
 
+
     @Test
     public void validateWithNullModelShouldThrowIllegalArgumentException() {
 

--- a/applications/harvester-api/src/test/resources/geonorge-spatial-resource.xml
+++ b/applications/harvester-api/src/test/resources/geonorge-spatial-resource.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:void="http://www.w3.org/TR/void/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:dctype="http://purl.org/dc/dcmitype/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:xslUtils="java:org.fao.geonet.util.XslUtil" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:locn="http://www.w3.org/ns/locn#" xmlns:gml="http://www.opengis.net/gml" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <dcat:Catalog rdf:about="http://www.geonorge.no/geonetwork">
+        <dct:title xml:lang="no">Geonorge</dct:title>
+        <dct:description>GeoNorge er den nasjonale katalogen for geografisk informasjon</dct:description>
+        <rdfs:label xml:lang="no">GeoNorge</rdfs:label>
+        <dct:publisher rdf:resource="https://register.geonorge.no/register/organisasjoner/kartverket/kartverket" />
+        <dcat:dataset rdf:resource="https://kartkatalog.geonorge.no/Metadata/uuid/041f1e6e-bdbc-4091-b48f-8a5990f3cc5b" />
+    </dcat:Catalog>
+    <dcat:Dataset rdf:about="https://kartkatalog.geonorge.no/Metadata/uuid/041f1e6e-bdbc-4091-b48f-8a5990f3cc5b">
+        <dct:identifier>041f1e6e-bdbc-4091-b48f-8a5990f3cc5b</dct:identifier>
+        <dct:title xml:lang="no">Test</dct:title>
+        <dct:description xml:lang="no">Datasett med ugyldig angivelse av spatial ressurs</dct:description>
+        <dct:spatial>https://data.geonorge.no/administrativeEnheter/kommune/id/173055"</dct:spatial>
+    </dcat:Dataset>
+    <foaf:Agent rdf:about="https://register.geonorge.no/register/organisasjoner/kartverket/kartverket">
+        <dct:type rdf:resource="http://purl.org/adms/publishertype/NationalAuthority"/>
+        <dct:identifier>971040238</dct:identifier>
+        <foaf:name>Kartverket</foaf:name>
+        <foaf:mbox>post@kartverket.no</foaf:mbox>
+        <owl:sameAs>http://data.brreg.no/enhetsregisteret/enhet/971040238</owl:sameAs>
+    </foaf:Agent>
+</rdf:RDF>

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/client/LoadLocations.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/client/LoadLocations.java
@@ -65,7 +65,13 @@ public class LoadLocations {
         ResIterator resIterator = model.listResourcesWithProperty(DCTerms.spatial);
         resIterator.forEachRemaining(datasetResource -> {
             datasetResource.listProperties(DCTerms.spatial).forEachRemaining(spatial -> {
-                String uri = AbstractBuilder.removeDefaultBaseUri(model, spatial.getObject().asResource().getURI());
+
+                String uri = null;
+                if(spatial.getObject().isResource()) {
+                    uri = AbstractBuilder.removeDefaultBaseUri(model, spatial.getObject().asResource().getURI());
+                } else {
+                    uri = spatial.getLiteral().getString();
+                }
 
                 if (uri != null && uri.startsWith("http")) {
                     if (existingLocationCodes == null || !existingLocationCodes.containsKey(uri)) {

--- a/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/client/LoadLocations.java
+++ b/libraries/datastore/src/main/java/no/dcat/datastore/domain/dcat/client/LoadLocations.java
@@ -70,6 +70,7 @@ public class LoadLocations {
                 if(spatial.getObject().isResource()) {
                     uri = AbstractBuilder.removeDefaultBaseUri(model, spatial.getObject().asResource().getURI());
                 } else {
+                    //Workaround to handle resource URI on the form <dct:spatial>someurl</dct:spatial>
                     uri = spatial.getLiteral().getString();
                 }
 


### PR DESCRIPTION
hotfix som gjør at harvester tolererer feil spesifikasjon av uri i dct:spatial i datasett uten at import stopper.

> check applicable boxes

- [x ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
