### PR TITLE
(nginx-search) API-554 make nginx-search force ssl

### DIFF
--- a/applications/nginx-search/src/main/docker/nginx.conf
+++ b/applications/nginx-search/src/main/docker/nginx.conf
@@ -17,6 +17,30 @@ http {
         listen 8080;
         server_name default_server;
 
+        #check if environment is temorary. If not, it is permanent (P)
+        #https redirect should only occur on permanent environments
+        if ($host ~ ^tmp-) {
+          set $tempenv 1;
+        }
+
+        if ($host ~ ^localhost) {
+          set $tempenv 1;
+        }
+
+        if ($tempenv != 1 ) {
+          set $test P;
+        }
+
+        #if http it is unsecure (U)
+        if ($http_x_forwarded_proto = "http") {
+           set $test "${test}U";
+        }
+
+        #if it is a permanent environment and it is unsecure
+        if ($test = PU) {
+           return 301 https://$host$request_uri;
+        }
+
         proxy_connect_timeout       600;
         proxy_send_timeout          600;
         proxy_read_timeout          600;


### PR DESCRIPTION
<!-- Paste inn the jira issue link below -->
Jira issue link: https://jira.brreg.no/browse/API-554

OBS!
Denne får vi ikke testet skikkelig før den er på plass i UT1-miljøet, men den så ut til å fungere i temp-miljø før jeg la på logikken som gjorde unntak for miljø som begynner på tmp-* og localhost.
Må derfor teste at logikken fungerer på ut1.