### PR TITLE
fix (search) API-880 api-details not show informatiomodels in sticky …

### DIFF
--- a/applications/search/src/pages/api-details-page/api-details-page.jsx
+++ b/applications/search/src/pages/api-details-page/api-details-page.jsx
@@ -294,7 +294,10 @@ const renderStickyMenu = (apiItem, informationModels) => {
       prefLabel: localization.datasetReferences
     });
   }
-  if (informationModels) {
+  if (
+    Array.isArray(informationModels) ||
+    (informationModels && informationModels.length === 0)
+  ) {
     menuItems.push({
       name: localization.informationModelReferences,
       prefLabel: localization.informationModelReferences
@@ -334,6 +337,7 @@ export const ApiDetailsPage = props => {
     identifier: apiItem.id,
     title: meta.title
   };
+
   return (
     <main id="content" className="container">
       <article>


### PR DESCRIPTION
…when not exists

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
