### PR TITLE
fix (registration-api) Only allow PATCH and POST method to change editable fields

### DIFF
--- a/applications/api-cat/pom.xml
+++ b/applications/api-cat/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>no.dcat</groupId>
             <artifactId>registration-api-bindings</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>no.dcat</groupId>

--- a/applications/informationmodel-cat/pom.xml
+++ b/applications/informationmodel-cat/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>no.dcat</groupId>
             <artifactId>registration-api-bindings</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>no.dcat</groupId>

--- a/applications/registration-api/pom.xml
+++ b/applications/registration-api/pom.xml
@@ -198,7 +198,7 @@
         <dependency>
             <groupId>no.dcat</groupId>
             <artifactId>registration-api-common</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
 
         <dependency>

--- a/applications/registration-api/src/main/java/no/dcat/controller/ApiRegistrationPublicController.java
+++ b/applications/registration-api/src/main/java/no/dcat/controller/ApiRegistrationPublicController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static no.fdk.registration.common.ApiRegistrationEditableProperties.REGISTRATION_STATUS_PUBLISH;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
@@ -51,7 +52,7 @@ public class ApiRegistrationPublicController {
     public PagedResources<ApiRegistrationPublic> getPublished(Pageable pageable, PagedResourcesAssembler assembler) {
 
         Page<ApiRegistration> apiRegistrationsPage =
-            apiRegistrationRepository.findByRegistrationStatus(ApiRegistration.REGISTRATION_STATUS_PUBLISH, pageable);
+            apiRegistrationRepository.findByRegistrationStatus(REGISTRATION_STATUS_PUBLISH, pageable);
 
         List<ApiRegistration> apiRegistrationList = apiRegistrationsPage.getContent();
         List<ApiRegistrationPublic> apiRegistrationPublicList = apiRegistrationList.stream()

--- a/applications/registration-api/src/main/java/no/dcat/model/ApiRegistration.java
+++ b/applications/registration-api/src/main/java/no/dcat/model/ApiRegistration.java
@@ -20,11 +20,6 @@ import java.util.Date;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
 public class ApiRegistration extends ApiRegistrationPublic {
-    public static final String REGISTRATION_STATUS_DRAFT = "DRAFT";
-    public static final String REGISTRATION_STATUS_PUBLISH = "PUBLISH";
-
-    private String registrationStatus = REGISTRATION_STATUS_DRAFT; // DRAFT is default
-
     private boolean isFromApiCatalog;
 
     private HarvestStatus harvestStatus;

--- a/applications/registration-api/src/main/java/no/dcat/model/ApiRegistrationFactory.java
+++ b/applications/registration-api/src/main/java/no/dcat/model/ApiRegistrationFactory.java
@@ -1,14 +1,20 @@
 package no.dcat.model;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import no.dcat.service.ApiCatService;
 import no.fdk.acat.bindings.ApiCatBindings;
+import no.fdk.registration.common.ApiRegistrationEditableProperties;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Date;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static no.fdk.registration.common.ApiRegistrationEditableProperties.REGISTRATION_STATUS_DRAFT;
 
 @Component
 public class ApiRegistrationFactory {
@@ -23,11 +29,9 @@ public class ApiRegistrationFactory {
 
         ApiRegistration apiRegistration = new ApiRegistration();
 
-//        BeanUtils.copyProperties(data, apiRegistration);
-
         apiRegistration.setId(UUID.randomUUID().toString());
         apiRegistration.setCatalogId(catalogId);
-        apiRegistration.setRegistrationStatus(ApiRegistration.REGISTRATION_STATUS_DRAFT);
+        apiRegistration.setRegistrationStatus(REGISTRATION_STATUS_DRAFT);
         apiRegistration.set_lastModified(new Date());
 
         return apiRegistration;
@@ -46,5 +50,36 @@ public class ApiRegistrationFactory {
         apiRegistration.setApiSpecification(apiCat.convertSpecUrlToApiSpecification(apiSpecUrl));
         apiRegistration.setApiSpecUrl(apiSpecUrl);
         apiRegistration.setApiSpec(null);
+    }
+
+    public void copyEditableProperties(ApiRegistration apiRegistration, Map<String, Object> updates) {
+        Gson gson = new Gson();
+
+        Set<String> editableFieldNames = Arrays.stream(ApiRegistrationEditableProperties.class.getDeclaredFields()).map(f -> f.getName()).collect(Collectors.toSet());
+
+        JsonObject apiRegistrationJson = gson.toJsonTree(apiRegistration).getAsJsonObject();
+
+        updates.entrySet().stream()
+            .filter(entry -> editableFieldNames.contains(entry.getKey()))
+            .forEach(entry -> {
+                JsonElement jsonValue = gson.toJsonTree(entry.getValue());
+                apiRegistrationJson.add(entry.getKey(), jsonValue); // JsonObject.add actually replaces value
+            });
+
+        ApiRegistration editedApiRegistration = gson.fromJson(apiRegistrationJson, ApiRegistration.class);
+
+        // copy all properties back to original object, including the edited ones
+        BeanUtils.copyProperties(editedApiRegistration, apiRegistration);
+
+        String apiSpecUrl = (String) updates.get("apiSpecUrl");
+        String apiSpec = (String) updates.get("apiSpec");
+
+        if (!StringUtils.isEmpty(apiSpecUrl)) {
+            setApiSpecificationFromSpecUrl(apiRegistration, apiSpecUrl);
+        } else if (!StringUtils.isEmpty(apiSpec)) {
+            setApiSpecificationFromSpec(apiRegistration, apiSpec);
+        }
+
+        apiRegistration.set_lastModified(new Date());
     }
 }

--- a/applications/registration-api/src/main/java/no/dcat/service/ApiCatalogHarvesterService.java
+++ b/applications/registration-api/src/main/java/no/dcat/service/ApiCatalogHarvesterService.java
@@ -23,10 +23,7 @@ import org.springframework.stereotype.Service;
 import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Sets up the Harvester that harvests from API Catalogs to Api Registrations (NOT from registrations to Search Indexes)

--- a/applications/registration-api/src/test/java/no/dcat/controller/ApiRegistrationControllerTest.java
+++ b/applications/registration-api/src/test/java/no/dcat/controller/ApiRegistrationControllerTest.java
@@ -2,6 +2,7 @@ package no.dcat.controller;
 
 import com.google.gson.Gson;
 import no.dcat.model.ApiRegistration;
+import no.fdk.registration.common.ApiRegistrationEditableProperties;
 import no.dcat.model.ApiRegistrationFactory;
 import no.dcat.model.Catalog;
 import no.dcat.service.ApiCatService;
@@ -24,8 +25,12 @@ import org.springframework.core.io.Resource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
+import static no.fdk.registration.common.ApiRegistrationEditableProperties.REGISTRATION_STATUS_DRAFT;
+import static no.fdk.registration.common.ApiRegistrationEditableProperties.REGISTRATION_STATUS_PUBLISH;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -79,8 +84,9 @@ public class ApiRegistrationControllerTest {
     @Test
     public void createApiRegistrationOK() throws Throwable {
 
-        ApiRegistration apiRegData = new ApiRegistration();
-        apiRegData.setApiSpecUrl(apiResource.getURL().toString());
+        Map<String, Object> apiRegData = new HashMap<String, Object>() {{
+            put("apiSpecUrl", apiResource.getURL().toString());
+        }};
 
         ApiRegistration saved = apiRegistrationController.createApiRegistration(catalogId, apiRegData);
 
@@ -112,7 +118,7 @@ public class ApiRegistrationControllerTest {
 
         ApiRegistration apiRegistration = new ApiRegistration();
         apiRegistration.setCatalogId(catalogId);
-        apiRegistration.setRegistrationStatus(ApiRegistration.REGISTRATION_STATUS_PUBLISH);
+        apiRegistration.setRegistrationStatus(REGISTRATION_STATUS_PUBLISH);
 
         when(apiRegistrationRepositoryMock.findById(id)).thenReturn(Optional.of(apiRegistration));
 
@@ -128,7 +134,7 @@ public class ApiRegistrationControllerTest {
 
         ApiRegistration apiRegistration = new ApiRegistration();
         apiRegistration.setCatalogId(catalogId);
-        apiRegistration.setRegistrationStatus(ApiRegistration.REGISTRATION_STATUS_DRAFT);
+        apiRegistration.setRegistrationStatus(REGISTRATION_STATUS_DRAFT);
 
         when(apiRegistrationRepositoryMock.findById(id)).thenReturn(Optional.of(apiRegistration));
 

--- a/libraries/registration-api-bindings/pom.xml
+++ b/libraries/registration-api-bindings/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>registration-api-bindings</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <properties>
         <!--standard properties-->
         <java.version>1.8</java.version>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>no.dcat</groupId>
             <artifactId>registration-api-common</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
 
     </dependencies>

--- a/libraries/registration-api-common/pom.xml
+++ b/libraries/registration-api-common/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>no.dcat</groupId>
     <artifactId>registration-api-common</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <properties>
         <!--standard properties-->
         <java.version>1.8</java.version>
@@ -28,6 +28,11 @@
             <groupId>no.dcat</groupId>
             <artifactId>api-cat-common</artifactId>
             <version>1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/libraries/registration-api-common/src/main/java/no/fdk/registration/common/ApiRegistrationEditableProperties.java
+++ b/libraries/registration-api-common/src/main/java/no/fdk/registration/common/ApiRegistrationEditableProperties.java
@@ -1,0 +1,54 @@
+package no.fdk.registration.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import no.fdk.acat.common.model.apispecification.ApiSpecification;
+
+import java.util.List;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiRegistrationEditableProperties {
+
+    public static final String REGISTRATION_STATUS_DRAFT = "DRAFT";
+    public static final String REGISTRATION_STATUS_PUBLISH = "PUBLISH";
+
+    private String registrationStatus;
+
+    @ApiModelProperty("The url of the specification which are used to harvest the specification ")
+    private String apiSpecUrl;
+
+    @ApiModelProperty("Original API spec")
+    private String apiSpec;
+
+    @ApiModelProperty("The url of the API documentation")
+    private String apiDocUrl;
+
+    @ApiModelProperty("The dataset references")
+    private List<String> datasetReferences;
+
+    private ApiSpecification apiSpecification;
+
+    @ApiModelProperty("Indication if the api is from an authoritative source (a National Component)")
+    private Boolean nationalComponent;
+
+    @ApiModelProperty("Indication if the api has open access")
+    private Boolean isOpenAccess;
+
+    @ApiModelProperty("Indication if the api has open licence")
+    private Boolean isOpenLicense;
+
+    @ApiModelProperty("Indication if the api is free")
+    private Boolean isFree;
+
+    private String cost;
+
+    private String usageLimitation;
+
+    private String performance;
+
+    private String availability;
+
+    private String status;
+}

--- a/libraries/registration-api-common/src/main/java/no/fdk/registration/common/ApiRegistrationPublic.java
+++ b/libraries/registration-api-common/src/main/java/no/fdk/registration/common/ApiRegistrationPublic.java
@@ -3,54 +3,13 @@ package no.fdk.registration.common;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
-import lombok.ToString;
-import no.fdk.acat.common.model.apispecification.ApiSpecification;
-
-import java.util.List;
 
 @Data
-@ToString(includeFieldNames = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ApiRegistrationPublic {
+public class ApiRegistrationPublic extends ApiRegistrationEditableProperties {
 
     private String id;
 
     @ApiModelProperty("Catalog id is equal to orgNr")
     private String catalogId;
-
-    @ApiModelProperty("The url of the specification which are used to harvest the specification ")
-    private String apiSpecUrl;
-
-    @ApiModelProperty("Original API spec")
-    private String apiSpec;
-
-    @ApiModelProperty("The url of the API documentation")
-    private String apiDocUrl;
-
-    @ApiModelProperty("The dataset references")
-    private List<String> datasetReferences;
-
-    private ApiSpecification apiSpecification;
-
-    @ApiModelProperty("Indication if the api is from an authoritative source (a National Component)")
-    private Boolean nationalComponent;
-
-    @ApiModelProperty("Indication if the api has open access")
-    private Boolean isOpenAccess;
-
-    @ApiModelProperty("Indication if the api has open licence")
-    private Boolean isOpenLicense;
-
-    @ApiModelProperty("Indication if the api is free")
-    private Boolean isFree;
-
-    private String cost;
-
-    private String usageLimitation;
-
-    private String performance;
-
-    private String availability;
-
-    private String status;
 }


### PR DESCRIPTION
Det er mange måte å gjøre dette - vi vil deklarere en valg av felter som vi lar bruker endre. Jeg valgte at de feltene er i parent klass. Kanskje det er ikke mest lesbar? vi kunne egentlig bare holde listen som string array også