### PR TITLE
feature (registration-api) We now give better error messages, and sup…

### DIFF
--- a/applications/registration-api/src/main/java/no/dcat/model/HarvestStatus.java
+++ b/applications/registration-api/src/main/java/no/dcat/model/HarvestStatus.java
@@ -14,4 +14,6 @@ public class HarvestStatus {
     public static HarvestStatus Error(String message) {
         return new HarvestStatus(false, message);
     }
+
+    public static HarvestStatus PartialSuccess(String message) {return new HarvestStatus(true, message);}
 }


### PR DESCRIPTION
…port partial loading of API-Catalogs

Vi gir nå, når api-katalogen laster, men noen av apiene den inneholder ikke kan harvestes, en kommaseparert liste over apier (urler) som feiler, og laster ikke disse. 
Har også opprettet ny status PARTIAL SUCCESS, som er success=true, men med feilmelding som lister de som feilet, til frontend, slik at frontend kan gi en god localized feilmelding