### PR TITLE
fix(registration-api): API-964 Api registration checkbox fields are a…

### DIFF
--- a/applications/registration-react/src/lib/noolean.js
+++ b/applications/registration-react/src/lib/noolean.js
@@ -1,0 +1,24 @@
+// in json, noolean (nullable boolean) is expressed as three values: true, false, null
+// in our forms, we have assigned value "" to null
+
+export function nooleanToString(nooleanValue) {
+  switch (nooleanValue) {
+    case true:
+      return 'true';
+    case false:
+      return 'false';
+    default:
+      return '';
+  }
+}
+
+export function stringToNoolean(stringValue) {
+  switch (stringValue) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    default:
+      return null;
+  }
+}

--- a/applications/registration-react/src/pages/api-registration-page/async-patch/async-patch.js
+++ b/applications/registration-react/src/pages/api-registration-page/async-patch/async-patch.js
@@ -1,12 +1,24 @@
 import axios from 'axios';
 import _ from 'lodash';
 import {
-  apiFormPatchSuccessAction,
-  apiFormPatchIsSavingAction,
   apiFormPatchErrorAction,
-  apiFormPatchJustPublishedOrUnPublishedAction
+  apiFormPatchIsSavingAction,
+  apiFormPatchJustPublishedOrUnPublishedAction,
+  apiFormPatchSuccessAction
 } from '../../../redux/modules/api-form-status';
 import { apiSuccessAction } from '../../../redux/modules/apis';
+import { stringToNoolean } from '../../../lib/noolean';
+
+const nooleanFields = [
+  'isFree',
+  'isOpenAccess',
+  'isOpenLicense',
+  'nationalComponent'
+];
+const convertToPatchValue = (value, field) =>
+  _.includes(nooleanFields, field) ? stringToNoolean(value) : value;
+const convertToPatchValues = formValues =>
+  _.mapValues(formValues, convertToPatchValue);
 
 export const asyncValidate = (values, dispatch, props) => {
   const { match } = props;
@@ -20,8 +32,10 @@ export const asyncValidate = (values, dispatch, props) => {
     dispatch(apiFormPatchIsSavingAction(apiId));
   }
 
+  const patchValues = convertToPatchValues(values);
+
   return axios
-    .patch(_.get(match, 'url'), values)
+    .patch(_.get(match, 'url'), patchValues)
     .then(response => {
       const apiRegistration = response && response.data;
       if (apiRegistration) {

--- a/applications/registration-react/src/pages/api-registration-page/form-access/connected-form-access.jsx
+++ b/applications/registration-react/src/pages/api-registration-page/form-access/connected-form-access.jsx
@@ -1,18 +1,18 @@
 import { getFormSyncErrors } from 'redux-form';
 import { connect } from 'react-redux';
-import _ from 'lodash';
 
 import { ConfiguredFormAccess } from './configured-form-access';
+import { nooleanToString } from '../../../lib/noolean';
 
 const mapStateToProps = ({ form }, ownProps) => {
-  const { apiItem } = ownProps;
+  const apiItem = (ownProps && ownProps.apiItem) || {};
   return {
     syncErrors: getFormSyncErrors('apiAccess')(form),
     initialValues: {
-      isOpenAccess: _.get(apiItem, 'isOpenAccess', '').toString(),
-      isOpenLicense: _.get(apiItem, 'isOpenLicense', '').toString(),
-      isFree: _.get(apiItem, 'isFree', '').toString(),
-      nationalComponent: _.get(apiItem, 'nationalComponent', '').toString()
+      isOpenAccess: nooleanToString(apiItem.isOpenAccess),
+      isOpenLicense: nooleanToString(apiItem.isOpenLicense),
+      isFree: nooleanToString(apiItem.isFree),
+      nationalComponent: nooleanToString(apiItem.nationalComponent)
     }
   };
 };


### PR DESCRIPTION
…ctually nullable booleans. Our forms do not support this type, therefore we must convert it to string.

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
