### PR TITLE
(api-cat) #1505 extended api-cat API to allow lookoup of APIs related…

### DIFF
--- a/applications/api-cat/src/main/resources/apidocument.mapping.json
+++ b/applications/api-cat/src/main/resources/apidocument.mapping.json
@@ -68,6 +68,9 @@
       "datasetReferences": {
         "dynamic": "false",
         "properties": {
+          "id" : {
+            "type" : "keyword"
+          },
           "title": {
             "type": "object",
             "dynamic": "true"


### PR DESCRIPTION
… to a particular dataset. api-cat API now allows user to specify return fields of apis query.
