### PR TITLE
Feature/bjg/update tls version

### DIFF
--- a/applications/registration-api/src/main/java/no/dcat/authorization/AuthorizationService.java
+++ b/applications/registration-api/src/main/java/no/dcat/authorization/AuthorizationService.java
@@ -39,8 +39,7 @@ import java.util.stream.Collectors;
 public class AuthorizationService {
     private static final Logger logger = LoggerFactory.getLogger(AuthorizationService.class);
 
-    static String[] TLS_PROTOCOLS = {"TLSv1", "TLSv1.1" /*, "TLSv1.2"*/}; // Comment in TLSv1.2 to fail : bug in altinn or java that fails TLS handshake most of the time, but not always
-    static String[] TLS_PROTOCOLSx = {"TLSv1.2"};
+    static String[] TLS_PROTOCOLS = {"TLSv1.2"};
     static String[] CIPHER_SUITES = null; // {"TLS_RSA_WITH_AES_128_GCM_SHA256"};
 
     @Value("${application.apikey}")


### PR DESCRIPTION
TLS nå satt til versjon 1.2 i stedet for 1.0 og 1.1, da Altinn kommer til å slutte å støtte 1.0 og 1.1.

Må testes i IT1 miljø