### PR TITLE
refactor(registration-react): Split out the datasetRegistrationEnsure…

### DIFF
--- a/applications/registration-react/src/lib/redux-dispatch-on-props-change.jsx
+++ b/applications/registration-react/src/lib/redux-dispatch-on-props-change.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+
+/*
+This enhancer is for assigning component a capability to dispatch actions on props change.
+
+changeFilter parameter
+  https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect
+
+  Examples:
+
+  - fire only once:
+    ()=>[]
+
+  - fire for change on props.id change
+    props => [props.match.params.id]
+
+  - default is is to change on any props change
+     () => undefined
+
+
+Complete usage example:
+
+  const dispatcher = (dispatch, props) => {
+    dispatch(someAction(props.someProp));
+  }
+
+  const changeFilter = props => [props.match.params.id]
+
+  const enhancer = withDispatchOnPropsChange(dispatcher,changeFilter);
+
+  const component=enhancer(componentPure);
+
+ */
+
+// by default launch effect on every props change
+// override with array returning function,
+// for example:  (props)=>[props.datasetId]
+const defaultChangeInputs = () => undefined;
+
+const withEffect = changeInputs => Component => props => {
+  useEffect(
+    props.dispatchOnEffect, // eslint-disable-line react/prop-types
+    (changeInputs || defaultChangeInputs)(props)
+  );
+  return <Component {...props} />;
+};
+
+const mapDispatchToProps = dispatchOnChange => (dispatch, ownProps) => ({
+  dispatchOnEffect: () => dispatchOnChange(dispatch, ownProps)
+});
+
+export const withDispatchOnPropsChange = (
+  dispatchOnChange,
+  changeFilter
+) => Component =>
+  connect(
+    undefined,
+    mapDispatchToProps(dispatchOnChange)
+  )(withEffect(changeFilter)(Component));

--- a/applications/registration-react/src/pages/dataset-registration-page/dataset-registration-connector.jsx
+++ b/applications/registration-react/src/pages/dataset-registration-page/dataset-registration-connector.jsx
@@ -1,8 +1,8 @@
-import { batch, connect } from 'react-redux';
+import { connect } from 'react-redux';
+import { compose } from 'recompose';
 import _ from 'lodash';
 
 import {
-  fetchDatasetsIfNeeded,
   getDatasetItemByDatasetiId,
   getDatasetItemsByCatalogId
 } from '../../redux/modules/datasets';
@@ -15,6 +15,7 @@ import {
   REFERENCEDATA_PATH_THEMES
 } from '../../redux/modules/referenceData';
 import { getDatasetFormStatusById } from '../../redux/modules/dataset-form-status';
+import { withInjectables } from '../../lib/injectables';
 
 const mapStateToProps = (
   { form, datasetFormStatus, datasets, referenceData },
@@ -106,53 +107,15 @@ const mapStateToProps = (
   };
 };
 
-const mapDispatchToProps = (
-  dispatch,
-  { match, referenceDataApiActions, datasetApiActions }
-) => ({
-  onChangeDatasetId: () => {
-    const catalogId = _.get(match, ['params', 'catalogId']);
-
-    batch(() => {
-      dispatch(fetchDatasetsIfNeeded(catalogId));
-      dispatch(
-        referenceDataApiActions.fetchReferenceDataIfNeededAction(
-          REFERENCEDATA_PATH_PROVENANCE
-        )
-      );
-      dispatch(
-        referenceDataApiActions.fetchReferenceDataIfNeededAction(
-          REFERENCEDATA_PATH_FREQUENCY
-        )
-      );
-      dispatch(
-        referenceDataApiActions.fetchReferenceDataIfNeededAction(
-          REFERENCEDATA_PATH_THEMES
-        )
-      );
-      dispatch(
-        referenceDataApiActions.fetchReferenceDataIfNeededAction(
-          REFERENCEDATA_PATH_REFERENCETYPES
-        )
-      );
-      dispatch(
-        referenceDataApiActions.fetchReferenceDataIfNeededAction(
-          REFERENCEDATA_PATH_OPENLICENCES
-        )
-      );
-      dispatch(
-        referenceDataApiActions.fetchReferenceDataIfNeededAction(
-          REFERENCEDATA_PATH_LOS
-        )
-      );
-    });
-  },
-
+const mapDispatchToProps = (dispatch, { datasetApiActions }) => ({
   deleteDatasetItem: (catalogId, datasetId) =>
     dispatch(datasetApiActions.deleteDatasetAction(catalogId, datasetId))
 });
 
-export const datasetRegistrationConnector = connect(
-  mapStateToProps,
-  mapDispatchToProps
+export const datasetRegistrationConnector = compose(
+  withInjectables(['datasetApiActions']),
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )
 );

--- a/applications/registration-react/src/pages/dataset-registration-page/dataset-registration-ensuredata.jsx
+++ b/applications/registration-react/src/pages/dataset-registration-page/dataset-registration-ensuredata.jsx
@@ -1,0 +1,59 @@
+import { batch } from 'react-redux';
+import { compose } from 'recompose';
+
+import _ from 'lodash';
+import { fetchDatasetsIfNeeded } from '../../redux/modules/datasets';
+import {
+  REFERENCEDATA_PATH_FREQUENCY,
+  REFERENCEDATA_PATH_LOS,
+  REFERENCEDATA_PATH_OPENLICENCES,
+  REFERENCEDATA_PATH_PROVENANCE,
+  REFERENCEDATA_PATH_REFERENCETYPES,
+  REFERENCEDATA_PATH_THEMES
+} from '../../redux/modules/referenceData';
+import { withDispatchOnPropsChange } from '../../lib/redux-dispatch-on-props-change';
+import { withInjectables } from '../../lib/injectables';
+
+const ensureData = (dispatch, props) => {
+  // dispatch actions to ensure store is populated fo render
+  const { match, referenceDataApiActions } = props;
+  const catalogId = _.get(match, ['params', 'catalogId']);
+  batch(() => {
+    dispatch(fetchDatasetsIfNeeded(catalogId));
+    dispatch(
+      referenceDataApiActions.fetchReferenceDataIfNeededAction(
+        REFERENCEDATA_PATH_PROVENANCE
+      )
+    );
+    dispatch(
+      referenceDataApiActions.fetchReferenceDataIfNeededAction(
+        REFERENCEDATA_PATH_FREQUENCY
+      )
+    );
+    dispatch(
+      referenceDataApiActions.fetchReferenceDataIfNeededAction(
+        REFERENCEDATA_PATH_THEMES
+      )
+    );
+    dispatch(
+      referenceDataApiActions.fetchReferenceDataIfNeededAction(
+        REFERENCEDATA_PATH_REFERENCETYPES
+      )
+    );
+    dispatch(
+      referenceDataApiActions.fetchReferenceDataIfNeededAction(
+        REFERENCEDATA_PATH_OPENLICENCES
+      )
+    );
+    dispatch(
+      referenceDataApiActions.fetchReferenceDataIfNeededAction(
+        REFERENCEDATA_PATH_LOS
+      )
+    );
+  });
+};
+
+export const datasetRegistrationEnsureData = compose(
+  withInjectables(['referenceDataApiActions', 'datasetApiActions']),
+  withDispatchOnPropsChange(ensureData, props => [props.match.params.id])
+);

--- a/applications/registration-react/src/pages/dataset-registration-page/dataset-registration-page-pure.jsx
+++ b/applications/registration-react/src/pages/dataset-registration-page/dataset-registration-page-pure.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { Link } from 'react-router-dom';
@@ -69,7 +69,6 @@ async function deleteAndNavigateToList({
 
 export function DatasetRegistrationPagePure(props) {
   const {
-    onChangeDatasetId,
     themesItems,
     provenanceItems,
     frequencyItems,
@@ -101,8 +100,6 @@ export function DatasetRegistrationPagePure(props) {
     history,
     deleteDatasetItem
   } = props;
-
-  useEffect(onChangeDatasetId, [props.datasetId]);
 
   const datasetURL = window.location.pathname;
   const catalogDatasetsURL = datasetURL.substring(
@@ -405,7 +402,6 @@ export function DatasetRegistrationPagePure(props) {
 }
 
 DatasetRegistrationPagePure.defaultProps = {
-  onChangeDatasetId: _.noop,
   catalogId: null,
   datasetId: null,
   themesItems: null,
@@ -439,7 +435,6 @@ DatasetRegistrationPagePure.defaultProps = {
 };
 
 DatasetRegistrationPagePure.propTypes = {
-  onChangeDatasetId: PropTypes.func,
   catalogId: PropTypes.string,
   datasetId: PropTypes.string,
   themesItems: PropTypes.array,

--- a/applications/registration-react/src/pages/dataset-registration-page/dataset-registration-page.jsx
+++ b/applications/registration-react/src/pages/dataset-registration-page/dataset-registration-page.jsx
@@ -1,10 +1,11 @@
 import { compose } from 'recompose';
+
 import { DatasetRegistrationPagePure } from './dataset-registration-page-pure';
 import { datasetRegistrationConnector } from './dataset-registration-connector';
-import { withInjectables } from '../../lib/injectables';
+import { datasetRegistrationEnsureData } from './dataset-registration-ensuredata';
 
 const enhance = compose(
-  withInjectables(['referenceDataApiActions', 'datasetApiActions']),
+  datasetRegistrationEnsureData,
   datasetRegistrationConnector
 );
 export const DatasetRegistrationPage = enhance(DatasetRegistrationPagePure);


### PR DESCRIPTION
…Data decorator from the datasetRegistrationConnector in order to clearly distinguish between data loading actions and state mapping

Den refaktorering er bare en ide, vi trenger ikke å implementere det i denne måte.

Spørsmål er, i hvilke sted deklarerer vi datakrav til en route component. Det finnes akkurat tre muligheter.

1) router - router kan ha en eventhandler så at vi dispatch dataLoad action on param change
2) connector i mellom. komponent bare sender en event onRender (eller lignende) og da connector skal dispatch listen av action.
3) komponent - komponent skal ha useEffect eller componentDidMount eller lignende, som dispatch dataLoad action til alt som det trenger.

Tidligere har vi bevegt fra 3 til 2. I denne PR er det forslag å pusher vi videre fra 2 til 1 (vel, router har ikke store dispatch, derfor bi pusher den dataload responsibility bare utenfor connector, mellom 1 og 2 da.


