### PR TITLE
Fix/tno/losfix

### DIFF
--- a/applications/reference-data/src/main/java/no/dcat/themes/service/LosRDFImporter.java
+++ b/applications/reference-data/src/main/java/no/dcat/themes/service/LosRDFImporter.java
@@ -177,7 +177,7 @@ public class LosRDFImporter {
 
         //Hovedkategori - /<keyword>
         if (node.getParents() == null || node.getParents().isEmpty()) {
-            generatedPaths.add(getMostSaneName(node).toLowerCase());
+            generatedPaths.add(getKeywordFromURI(node.getUri()).toLowerCase());
             return generatedPaths;
         }
 

--- a/applications/reference-data/src/main/resources/application.yml
+++ b/applications/reference-data/src/main/resources/application.yml
@@ -5,7 +5,7 @@ logging:
   level.o.apache: ERROR
   level.no.brreg: ERROR
   level.no.difi: ERROR
-  level.no.dcat: INFO
+  level.no: ${LOG_LEVEL:DEBUG}
   level.org.springframework: WARN
   level.org.springframework.web: WARN
 server:


### PR DESCRIPTION
 fix(reference-data): Fixes regression bug where toplevel LOS themes had spaces, not dashes
