### PR TITLE
sprint-fix(registration-react): #1949 In FilterPillsLos, revert onCha…

### DIFF
--- a/applications/registration-react/src/pages/dataset-registration-page/form-los/filter-pills-los/filter-pills-los.component.jsx
+++ b/applications/registration-react/src/pages/dataset-registration-page/form-los/filter-pills-los/filter-pills-los.component.jsx
@@ -33,7 +33,8 @@ const renderFilterPills = (input, losItems) => {
                 type="text"
                 defaultValue={_.get(item, 'uri')}
                 checked={false}
-                onChange={e => {
+                readOnly
+                onClick={e => {
                   handleUpdateField(input, e);
                 }}
                 label={getTranslateText(_.get(item, 'name'))}


### PR DESCRIPTION
…nge to onCLick and set to to readonly to satisfy the missing onChange warning

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
