### PR TITLE
fix(sso): Set DB_VENDOR to embedded h2, due to just existence of exis…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     environment:
       - KEYCLOAK_USER
       - KEYCLOAK_PASSWORD
+      - DB_VENDOR=h2
 
 ### ingress modules
   nginx-search:


### PR DESCRIPTION
…tence "postgres" host caused keycloak to use it.

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
