### PR TITLE
conf(sso): Use more reliable wait_for_http_200 script for getting idp…

### DIFF
--- a/applications/sso/tools/preprocess-import-entrypoint.sh
+++ b/applications/sso/tools/preprocess-import-entrypoint.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 echo "Processing import template"
 echo "IDPORTEN_OIDC_ROOT=$IDPORTEN_OIDC_ROOT"
 echo "IDPORTEN_CLIENT_ID=$IDPORTEN_CLIENT_ID"
 
-OIDC_CONF=$(curl $IDPORTEN_OIDC_ROOT/.well-known/openid-configuration)
+
+OIDC_CONF_ADDRESS=$IDPORTEN_OIDC_ROOT/.well-known/openid-configuration
+
+source ${__dir}/wait_for_http_200.sh $OIDC_CONF_ADDRESS
+
+OIDC_CONF=$(curl $OIDC_CONF_ADDRESS)
 
 if [ -z "$OIDC_CONF" ]
 then

--- a/applications/sso/tools/wait_for_http_200.sh
+++ b/applications/sso/tools/wait_for_http_200.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+url=($1)
+echo "Waiting 200 from " $url
+while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' $url)" != "200" ]];
+    do sleep 5;
+    echo "Retrying " $url;
+done
+echo "Success 200 from " $url

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -51,9 +51,6 @@ services:
 #      - KEYCLOAK_LOGLEVEL=DEBUG
     ports:
       - "8084:8080"
-# sso-idporten-mock serves ./well-known/openid-configuration endpoint
-# fail and restart until the endpoint is ready.
-    restart: on-failure
     depends_on:
       - sso-idporten-mock
 


### PR DESCRIPTION
…orten configuration, instead of docker-compose restart on error

<!-- Paste inn the jira issue link below -->
Jira issue link: [link](LINK_HERE)

> check applicable boxes

- [ ] I have made tests to match the user stories
- [ ] This code does not require tests that match user stories
