### PR TITLE
chore: Remove unnecessary 'touch /app.jar' from java containers

### DIFF
--- a/applications/api-cat/src/main/docker/Dockerfile
+++ b/applications/api-cat/src/main/docker/Dockerfile
@@ -5,5 +5,5 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 VOLUME /tmp
 ADD *-exec.jar app.jar
-RUN sh -c 'touch /app.jar'
+
 CMD java -jar  $JAVA_OPTS app.jar

--- a/applications/concept-cat/src/main/docker/Dockerfile
+++ b/applications/concept-cat/src/main/docker/Dockerfile
@@ -5,5 +5,5 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 VOLUME /tmp
 ADD *-exec.jar app.jar
-RUN sh -c 'touch /app.jar'
+
 CMD java -jar  $JAVA_OPTS app.jar

--- a/applications/dev-management/src/main/docker/Dockerfile
+++ b/applications/dev-management/src/main/docker/Dockerfile
@@ -5,5 +5,5 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 VOLUME /tmp
 ADD *-exec.jar app.jar
-RUN sh -c 'touch /app.jar'
+
 CMD java -jar $JAVA_OPTS app.jar

--- a/applications/harvester-api/src/main/docker/Dockerfile
+++ b/applications/harvester-api/src/main/docker/Dockerfile
@@ -5,6 +5,5 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 VOLUME /tmp
 ADD *-exec.jar app.jar
-RUN sh -c 'touch /app.jar'
 
 CMD java -jar  $JAVA_OPTS app.jar

--- a/applications/harvester/src/main/docker/Dockerfile
+++ b/applications/harvester/src/main/docker/Dockerfile
@@ -5,5 +5,5 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 VOLUME /tmp
 ADD *.jar app.jar
-RUN sh -c 'touch /app.jar'
+
 CMD java -jar  $JAVA_OPTS app.jar

--- a/applications/informationmodel-cat/src/main/docker/Dockerfile
+++ b/applications/informationmodel-cat/src/main/docker/Dockerfile
@@ -5,5 +5,5 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 VOLUME /tmp
 ADD *-exec.jar app.jar
-RUN sh -c 'touch /app.jar'
+
 CMD java -jar  $JAVA_OPTS app.jar

--- a/applications/reference-data/src/main/docker/Dockerfile
+++ b/applications/reference-data/src/main/docker/Dockerfile
@@ -5,5 +5,5 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 VOLUME /tmp
 ADD *-exec.jar app.jar
-RUN sh -c 'touch /app.jar'
+
 CMD java -jar $JAVA_OPTS app.jar

--- a/applications/registration-api/src/main/docker/Dockerfile
+++ b/applications/registration-api/src/main/docker/Dockerfile
@@ -11,6 +11,6 @@ RUN ls -l conf/
 
 VOLUME /tmp
 ADD *-exec.jar app.jar
-RUN sh -c 'touch /app.jar'
+
 CMD java -jar $JAVA_OPTS app.jar
 

--- a/applications/registration-auth/src/main/docker/Dockerfile
+++ b/applications/registration-auth/src/main/docker/Dockerfile
@@ -4,7 +4,6 @@ ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 ADD *-exec.jar app.jar
-RUN sh -c 'touch /app.jar'
 
 CMD java -jar  $JAVA_OPTS app.jar
 

--- a/applications/search-api/src/main/docker/Dockerfile
+++ b/applications/search-api/src/main/docker/Dockerfile
@@ -5,5 +5,5 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 VOLUME /tmp
 ADD *.jar app.jar
-RUN sh -c 'touch /app.jar'
+
 CMD java -jar  $JAVA_OPTS app.jar


### PR DESCRIPTION
Det kompilerer, og minst søke-apier kommer opp.